### PR TITLE
German translations of rdfs:label values and (some) summaries (#41)

### DIFF
--- a/modules/gfo-base.owl
+++ b/modules/gfo-base.owl
@@ -34,6 +34,7 @@
   <!-- Classes -->
   <owl:Class rdf:about="https://w3id.org/gfo/base/Abstract">
     <rdfs:label xml:lang="en">Abstract</rdfs:label>
+    <rdfs:label xml:lang="de">Abstraktes Individuum</rdfs:label>
     <skos:definition xml:lang="en">Abstract individuals are independent from time and space (they are
       not in time and space).
       Examples: the number "2" or pi.</skos:definition>
@@ -44,6 +45,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Action">
     <rdfs:label xml:lang="en">Action</rdfs:label>
+    <rdfs:label xml:lang="de">Aktivität</rdfs:label>
     <skos:definition xml:lang="en">Actions are occurrents which are caused by some presential (the
       agent) at every (inner and outer) time-boundary of the chronoid framing the occurrent.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Occurrent" />
@@ -57,6 +59,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Amount_of_substrate">
     <rdfs:label xml:lang="en">Amount of substrate</rdfs:label>
+    <rdfs:label xml:lang="de">Menge von Substrat</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Continuous" />
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Presential" />
     <owl:equivalentClass rdf:resource="https://w3id.org/gfo/base/Mass_entity" />
@@ -64,6 +67,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Awareness_level">
     <rdfs:label xml:lang="en">Awareness level</rdfs:label>
+    <rdfs:label xml:lang="de">Bewusstseins-Stufe</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Level" />
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -75,6 +79,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Biological_level">
     <rdfs:label xml:lang="en">Biological level</rdfs:label>
+    <rdfs:label xml:lang="de">Biologische Stufe</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Level" />
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -86,6 +91,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Category">
     <rdfs:label xml:lang="en">Category</rdfs:label>
+    <rdfs:label xml:lang="de">Kategorie</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Categories satisfy the
       following conditions: (1) Categories can be instantiated; (2) Categories can be predicated of
       other entities.
@@ -97,6 +103,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Change">
     <rdfs:label xml:lang="en">Change</rdfs:label>
+    <rdfs:label xml:lang="de">Veränderung</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A change in the technical
       sense refers to a pair of process
       boundaries. Either at coinciding boundaries (then it comes close to
@@ -114,6 +121,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Chemical_level">
     <rdfs:label xml:lang="en">Chemical level</rdfs:label>
+    <rdfs:label xml:lang="de">Chemische Stufe</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Level" />
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -125,6 +133,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Chronoid">
     <rdfs:label xml:lang="en">Chronoid</rdfs:label>
+    <rdfs:label xml:lang="de">Chronoid</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chronoids are entities sui
       generis.
 
@@ -136,6 +145,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Concept">
     <rdfs:label xml:lang="en">Concept</rdfs:label>
+    <rdfs:label xml:lang="de">Konzept</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Category" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Symbol_structure" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Universal" />
@@ -143,6 +153,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Concrete">
     <rdfs:label xml:lang="en">Concrete</rdfs:label>
+    <rdfs:label xml:lang="de">Festes Individuum</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Concrete individuals have a
       relation to time or space (they are in time and space).</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Individual" />
@@ -152,6 +163,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Configuration">
     <rdfs:label xml:lang="en">Configuration</rdfs:label>
+    <rdfs:label xml:lang="de">Konfiguration</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">We consider a collection of
       presential facts which exist at the same time-boundary. Such collections may be considered
       themselves as presentials, and we call them configurations.
@@ -164,6 +176,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Configuroid">
     <rdfs:label xml:lang="en">Configuroid</rdfs:label>
+    <rdfs:label xml:lang="de">Configuroid</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Configuroids are, in the
       simplest case, integrated wholes made up of material structure processes and property
       processes.</skos:definition>
@@ -172,6 +185,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Continuous">
     <rdfs:label xml:lang="en">Continuous</rdfs:label>
+    <rdfs:label xml:lang="de">Beständiges Individuum</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Individual" />
     <owl:intersectionOf rdf:parseType="Collection">
       <rdf:Description rdf:about="https://w3id.org/gfo/base/Individual" />
@@ -183,6 +197,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Continuous_change">
     <rdfs:label xml:lang="en">Continuous change</rdfs:label>
+    <rdfs:label xml:lang="de">Beständige Veränderung</rdfs:label>
     <skos:definition xml:lang="en">For the purpose of formalizing continuous changes, a minimal
       chronoid universal D(c) is employed in order to capture the idea of observable differences
       during certain chronoids, whereas the change itself does not allow the observation of a
@@ -194,6 +209,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Continuous_process">
     <rdfs:label xml:lang="en">Continuous process</rdfs:label>
+    <rdfs:label xml:lang="de">Beständiger Prozess</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Processes where all
       non-coinciding internal boundaries are intrinsic changes.
       These turn out as purely continuous processes, described e.g.
@@ -205,6 +221,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Dependent">
     <rdfs:label xml:lang="en">Dependent</rdfs:label>
+    <rdfs:label xml:lang="de">Abhängiges Individuum</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Individual" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Independent" />
     <owl:equivalentClass>
@@ -217,11 +234,13 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Discrete">
     <rdfs:label xml:lang="en">Discrete</rdfs:label>
+    <rdfs:label xml:lang="de">Diskretes Individuum</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Individual" />
   </owl:Class>
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Discrete_presential">
     <rdfs:label xml:lang="en">Discrete presential</rdfs:label>
+    <rdfs:label xml:lang="de">Diskreter Persistent</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Discrete" />
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Presential" />
     <rdfs:subClassOf>
@@ -235,6 +254,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Discrete_process">
     <rdfs:label xml:lang="en">Discrete process</rdfs:label>
+    <rdfs:label xml:lang="de">Diskreter Prozess</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Discrete processes are made
       up of alterations of extrinsic changes and states.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Discrete" />
@@ -244,6 +264,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Entity">
     <rdfs:label xml:lang="en">Entity</rdfs:label>
+    <rdfs:label xml:lang="de">Entität</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Everything which exists is
       called an entity.</skos:definition>
     <owl:unionOf rdf:parseType="Collection">
@@ -264,6 +285,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Function">
     <rdfs:label xml:lang="en">Function</rdfs:label>
+    <rdfs:label xml:lang="de">Funktion</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A function F is a universal
       (conceptual structure) defined in purely teleological terms with respect to a given goal G
       which commonly is ascribed by means of has-function relation to entities that are the
@@ -290,12 +312,14 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Independent">
     <rdfs:label xml:lang="en">Independent</rdfs:label>
+    <rdfs:label xml:lang="de">Unabhängiges Individuum</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Individual" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Dependent" />
   </owl:Class>
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Individual">
     <rdfs:label xml:lang="en">Individual</rdfs:label>
+    <rdfs:label xml:lang="de">Individuum</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Individuals are entities
       which cannot be further instantiated.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Item" />
@@ -342,6 +366,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Instantaneous_change">
     <rdfs:label xml:lang="en">Instantaneous change</rdfs:label>
+    <rdfs:label xml:lang="de">Unmittelbare Veränderung</rdfs:label>
     <skos:definition xml:lang="en">Instantaneous changes are represented by change(e1,e2, u1, u2, u),
       where e1 and e2 are a pair of coincident process boundaries, and u1 and u2 are disjoint
       sub-universals of u. Instantaneous changes are therefore changes of properties on two
@@ -364,6 +389,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Item">
     <rdfs:label xml:lang="en">Item</rdfs:label>
+    <rdfs:label xml:lang="de">Element</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An item is everything which
       is not a set. Also called ur-element.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Entity" />
@@ -386,6 +412,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Level">
     <rdfs:label xml:lang="en">Level</rdfs:label>
+    <rdfs:label xml:lang="de">Bereich</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An ontological level, which
       is sth. more restricted and "part of" some gfo:Stratum.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Ontological_layer" />
@@ -400,6 +427,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Line">
     <rdfs:label xml:lang="en">Line</rdfs:label>
+    <rdfs:label xml:lang="de">Linie</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Spatial_boundary" />
     <owl:equivalentClass>
       <owl:Restriction>
@@ -411,6 +439,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Mass_entity">
     <rdfs:label xml:lang="en">Mass entity</rdfs:label>
+    <rdfs:label xml:lang="de">Masse-Entität</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Continuous" />
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Presential" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Discrete_presential" />
@@ -418,6 +447,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Material_boundary">
     <rdfs:label xml:lang="en">Material boundary</rdfs:label>
+    <rdfs:label xml:lang="de">Materielle Grenze</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Dependent" />
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Presential" />
     <rdfs:subClassOf>
@@ -432,6 +462,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Material_line">
     <rdfs:label xml:lang="en">Material line</rdfs:label>
+    <rdfs:label xml:lang="de">Materielle Linie</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Material_boundary" />
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -445,6 +476,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Material_object">
     <rdfs:label xml:lang="en">Material object</rdfs:label>
+    <rdfs:label xml:lang="de">Materielles Objekt</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A material structure is an
       individual which satisfies the following conditions:
       it is a presential, it occupies space, it is a bearer of qualities, but other entities cannot
@@ -470,6 +502,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Material_persistant">
     <rdfs:label xml:lang="en">Material persistant</rdfs:label>
+    <rdfs:label xml:lang="de">Materieller Persistent</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Material persistants are
       particular universals whose instances are
       material structures; they are related to those entities which are called
@@ -492,6 +525,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Material_point">
     <rdfs:label xml:lang="en">Material point</rdfs:label>
+    <rdfs:label xml:lang="de">Materieller Punkt</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Material_boundary" />
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -505,6 +539,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Material_stratum">
     <rdfs:label xml:lang="en">Material stratum</rdfs:label>
+    <rdfs:label xml:lang="de">Materielle Ebene</rdfs:label>
     <skos:definition xml:lang="en">According to (Poli, 2001), the basic structure of the material
       stratum is a distinction of physical, chemical and biological levels.
       These levels can be further refined.</skos:definition>
@@ -513,12 +548,14 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Material_structure">
     <rdfs:label xml:lang="en">Material structure</rdfs:label>
+    <rdfs:label xml:lang="de">Materielle Struktur</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Discrete_presential" />
     <owl:equivalentClass rdf:resource="https://w3id.org/gfo/base/Material_object" />
   </owl:Class>
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Material_surface">
     <rdfs:label xml:lang="en">Material surface</rdfs:label>
+    <rdfs:label xml:lang="de">Materielle Fläche</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Material_boundary" />
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -532,6 +569,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Mental_stratum">
     <rdfs:label xml:lang="en">Mental stratum</rdfs:label>
+    <rdfs:label xml:lang="de">Geistige Ebene</rdfs:label>
     <skos:definition xml:lang="en">In accordance with the work of R. Poli, we divide the
       psychological/mental stratum into the layer of
       awareness and the layer of
@@ -544,6 +582,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Occurrent">
     <rdfs:label xml:lang="en">Occurrent</rdfs:label>
+    <rdfs:label xml:lang="de">Auftretendes Individuum</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Occurrents have temporal
       parts and thus cannot be present at a time-boundary. Time
       belongs to them, because they happen in time and the time of the occurrent
@@ -557,6 +596,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Ontological_layer">
     <rdfs:label xml:lang="en">Ontological layer</rdfs:label>
+    <rdfs:label xml:lang="de">Ontologische Ebene</rdfs:label>
     <rdfs:comment xml:lang="en">Ontological_layer, all of its sub concepts and the properties
       layer_of and on_layer are work in progress in a premature beta state.</rdfs:comment>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A collective term for
@@ -567,6 +607,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Persistant">
     <rdfs:label xml:lang="en">Persistant</rdfs:label>
+    <rdfs:label xml:lang="de">Persistent</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Persistants are GFO's way
       to capture identity over time.
 
@@ -587,6 +628,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Personality_level">
     <rdfs:label xml:lang="en">Personality level</rdfs:label>
+    <rdfs:label xml:lang="de">Persönlichkeitsstufe</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Level" />
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -598,6 +640,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Physical_level">
     <rdfs:label xml:lang="en">Physical level</rdfs:label>
+    <rdfs:label xml:lang="de">Physikalische Stufe</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Level" />
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -609,6 +652,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Point">
     <rdfs:label xml:lang="en">Point</rdfs:label>
+    <rdfs:label xml:lang="de">Punkt</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Spatial_boundary" />
     <owl:equivalentClass>
       <owl:Restriction>
@@ -620,6 +664,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Presential">
     <rdfs:label xml:lang="en">Presential</rdfs:label>
+    <rdfs:label xml:lang="de">Präsentes Individuum</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A presential exists wholly
       at exactly one time boundary.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Concrete" />
@@ -641,6 +686,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Process">
     <rdfs:label xml:lang="en">Process</rdfs:label>
+    <rdfs:label xml:lang="de">Prozess</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Processes are a special
       kind of occurrent. Processes are directly in time, they have characteristics which cannot be
       captured by a collection of time boundaries.</skos:definition>
@@ -651,6 +697,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Processual_role">
     <rdfs:label xml:lang="en">Processual role</rdfs:label>
+    <rdfs:label xml:lang="de">Prozessuale Rolle</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Processual roles are
       dependent processes. They are roles with a process as context.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Process" />
@@ -667,6 +714,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Property">
     <rdfs:label xml:lang="en">Property</rdfs:label>
+    <rdfs:label xml:lang="de">Eigenschaft</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Concrete" />
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Dependent" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Relator" />
@@ -674,6 +722,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Property_value">
     <rdfs:label xml:lang="en">Property value</rdfs:label>
+    <rdfs:label xml:lang="de">Eigenschaftswert</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The concept of a property
       value reflects a relationship between the property of x and the same property as exhibited by
       another entity y.</skos:definition>
@@ -689,6 +738,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Relational_role">
     <rdfs:label xml:lang="en">Relational role</rdfs:label>
+    <rdfs:label xml:lang="de">Relationale Rolle</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Dependent" />
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Role" />
     <rdfs:subClassOf>
@@ -703,17 +753,20 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Relator">
     <rdfs:label xml:lang="en">Relator</rdfs:label>
+    <rdfs:label xml:lang="de">Relator</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Individual" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Property" />
   </owl:Class>
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Role">
     <rdfs:label xml:lang="en">Role</rdfs:label>
+    <rdfs:label xml:lang="de">Rolle</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Concrete" />
   </owl:Class>
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Set">
     <rdfs:label xml:lang="en">Set</rdfs:label>
+    <rdfs:label xml:lang="de">Menge</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Set is a category
       pertaining to the individuals in the ZFC set theory.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Entity" />
@@ -722,6 +775,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Situation">
     <rdfs:label xml:lang="en">Situation</rdfs:label>
+    <rdfs:label xml:lang="de">Situation</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A situation is a special
       configuration which can be comprehended as a whole and satisfies certain conditions of unity,
       which are imposed by relations and categories associated with the situation. Herein, we
@@ -731,6 +785,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Situoid">
     <rdfs:label xml:lang="en">Situoid</rdfs:label>
+    <rdfs:label xml:lang="de">Situoid</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Situoids are processes
       whose boundaries are situations and which satisfy certain principles of coherence,
       comprehensibility, and continuity. They are regarded as the most complex integrated wholes of
@@ -742,6 +797,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Social_role">
     <rdfs:label xml:lang="en">Social role</rdfs:label>
+    <rdfs:label xml:lang="de">Soziale Rolle</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Independent" />
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Role" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Processual_role" />
@@ -750,6 +806,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Social_stratum">
     <rdfs:label xml:lang="en">Social stratum</rdfs:label>
+    <rdfs:label xml:lang="de">Soziale Ebene</rdfs:label>
     <skos:definition xml:lang="en">On the one hand, the social stratum is
       divided into Agents and
       Institutions. Agents are the bearers of the social
@@ -763,6 +820,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Space">
     <rdfs:label xml:lang="en">Space</rdfs:label>
+    <rdfs:label xml:lang="de">Raum</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GFO uses Brentano space.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Space_time" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Time" />
@@ -770,6 +828,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Space_time">
     <rdfs:label xml:lang="en">Space time</rdfs:label>
+    <rdfs:label xml:lang="de">Raum-Zeit</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Individual" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Abstract" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Concrete" />
@@ -777,6 +836,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Spatial_boundary">
     <rdfs:label xml:lang="en">Spatial boundary</rdfs:label>
+    <rdfs:label xml:lang="de">Räumliche Grenze</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Boundaries of regions are
       surfaces, boundaries of
       surfaces are lines, and boundaries of lines are
@@ -795,6 +855,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Spatial_region">
     <rdfs:label xml:lang="en">Spacial region</rdfs:label>
+    <rdfs:label xml:lang="de">Räumlicher Bereich</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Space regions are
       mereological sums of topoids.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Space" />
@@ -803,6 +864,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/State">
     <rdfs:label xml:lang="en">State</rdfs:label>
+    <rdfs:label xml:lang="de">Zustand</rdfs:label>
     <skos:definition xml:lang="en">A process without an instantaneous change at any of its inner time
       boundaries is called a state.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Process" />
@@ -810,6 +872,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Stratum">
     <rdfs:label xml:lang="en">Stratum</rdfs:label>
+    <rdfs:label xml:lang="de">Ebene</rdfs:label>
     <skos:definition xml:lang="en">According to (Poli, 2001, 2002) (based
       on the philosopher Hartmann) we distinguish at least three ontological
       strata of the world: the material stratum, the
@@ -829,6 +892,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Surface">
     <rdfs:label xml:lang="en">Surface</rdfs:label>
+    <rdfs:label xml:lang="de">Fläche</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Spatial_boundary" />
     <owl:equivalentClass>
       <owl:Restriction>
@@ -840,16 +904,19 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Symbol">
     <rdfs:label xml:lang="en">Symbol</rdfs:label>
+    <rdfs:label xml:lang="de">Symbol</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Symbol_structure" />
   </owl:Class>
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Symbol_sequence">
     <rdfs:label xml:lang="en">Symbol sequence</rdfs:label>
+    <rdfs:label xml:lang="de">Symbolsequenz</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Symbol_structure" />
   </owl:Class>
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Symbol_structure">
     <rdfs:label xml:lang="en">Symbol structure</rdfs:label>
+    <rdfs:label xml:lang="de">Symbolstruktur</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Category" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Concept" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Universal" />
@@ -857,6 +924,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Temporal_region">
     <rdfs:label xml:lang="en">Temporal region</rdfs:label>
+    <rdfs:label xml:lang="de">Zeitliche Ebene</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Time Regions are defined as
       the mereological sum of chronoids,
       i.e. time regions may consist of non-connected intervals of time.</skos:definition>
@@ -866,6 +934,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Time">
     <rdfs:label xml:lang="en">Time</rdfs:label>
+    <rdfs:label xml:lang="de">Zeit</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The time model of GFO is
       based on Brentano and the glass continuum of Allen&amp;Hayes.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Space_time" />
@@ -874,6 +943,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Time_boundary">
     <rdfs:label xml:lang="en">Time boundary</rdfs:label>
+    <rdfs:label xml:lang="de">Zeitliche Grenze</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Time boundaries depend on a
       chronoids (i.e. they have no independent
       existence) and can coincide.</skos:definition>
@@ -889,6 +959,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Token">
     <rdfs:label xml:lang="en">Token</rdfs:label>
+    <rdfs:label xml:lang="de">Zeichen</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Concrete" />
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -900,6 +971,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Topoid">
     <rdfs:label xml:lang="en">Topoid</rdfs:label>
+    <rdfs:label xml:lang="de">Topoid</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Topoids are connected
       compact regions of space. They have spatial boundaries.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Spatial_region" />
@@ -907,6 +979,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Universal">
     <rdfs:label xml:lang="en">Universal</rdfs:label>
+    <rdfs:label xml:lang="de">Universal</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Universals are immanent
       universals. They exist in re.</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Category" />
@@ -922,6 +995,7 @@
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Value_space">
     <rdfs:label xml:lang="en">Value space</rdfs:label>
+    <rdfs:label xml:lang="de">Wertebereich</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Property values usually
       appear in groups which are called value structures, value spaces or measurement systems.
       Each of these structures corresponds to some property. More intuitively, one could say that
@@ -961,6 +1035,7 @@
   <!-- Object Properties -->
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/abstract_has_part">
     <rdfs:label xml:lang="en">abstract has part</rdfs:label>
+    <rdfs:label xml:lang="de">Abstraktes hat-Bestandteil</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty" />
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Item" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Item" />
@@ -969,6 +1044,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/abstract_part_of">
     <rdfs:label xml:lang="en">abstract part of</rdfs:label>
+    <rdfs:label xml:lang="de">Abstrakte ist-Bestandteil-von-Beziehung</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty" />
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The abstract part-of
       relation is denoted by p(x,y);
@@ -983,6 +1059,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/agent_in">
     <rdfs:label xml:lang="en">agent in</rdfs:label>
+    <rdfs:label xml:lang="de">Vertreter in</rdfs:label>
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/causes" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/participates_in" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_agent" />
@@ -990,24 +1067,28 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/boundary_of">
     <rdfs:label xml:lang="en">boundary of</rdfs:label>
+    <rdfs:label xml:lang="de">Grenze von</rdfs:label>
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/depends_on" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_boundary" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/categorial_part_of">
     <rdfs:label xml:lang="en">categorial part of</rdfs:label>
+    <rdfs:label xml:lang="de">Kategorial ist-Bestandteil-von</rdfs:label>
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/abstract_part_of" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_categorial_part" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/category_in_layer">
     <rdfs:label xml:lang="en">category in layer</rdfs:label>
+    <rdfs:label xml:lang="de">Kategorie in der Ebene</rdfs:label>
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/categorial_part_of" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_category" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/caused_by">
     <rdfs:label xml:lang="en">caused by</rdfs:label>
+    <rdfs:label xml:lang="de">Verursacht von</rdfs:label>
     <rdfs:domain rdf:nodeID="b4" />
     <rdfs:range rdf:nodeID="b4" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/causes" />
@@ -1015,17 +1096,20 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/causes">
     <rdfs:label xml:lang="en">causes</rdfs:label>
+    <rdfs:label xml:lang="de">verursachen</rdfs:label>
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/caused_by" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/constituent_part_of">
     <rdfs:label xml:lang="en">constituent part of</rdfs:label>
+    <rdfs:label xml:lang="de">Konstituierend ist-Bestandteil-von</rdfs:label>
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/proper_part_of" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_constituent_part" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/depends_on">
     <rdfs:label xml:lang="en">depends on</rdfs:label>
+    <rdfs:label xml:lang="de">abhängig von</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation captures the
       notion of existential dependence.</skos:definition>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Item" />
@@ -1035,6 +1119,7 @@
 
   <owl:FunctionalProperty rdf:about="https://w3id.org/gfo/base/exists_at">
     <rdfs:label xml:lang="en">exists at</rdfs:label>
+    <rdfs:label xml:lang="de">existiert an</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Presential" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Time_boundary" />
@@ -1042,6 +1127,7 @@
 
   <owl:FunctionalProperty rdf:about="https://w3id.org/gfo/base/framed_by">
     <rdfs:label xml:lang="en">framed by</rdfs:label>
+    <rdfs:label xml:lang="de">eingerahmt durch</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Material_object" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Topoid" />
@@ -1051,6 +1137,7 @@
 
   <owl:InverseFunctionalProperty rdf:about="https://w3id.org/gfo/base/frames">
     <rdfs:label xml:lang="en">frames</rdfs:label>
+    <rdfs:label xml:lang="de">rahmen ein</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Topoid" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Material_object" />
@@ -1059,16 +1146,19 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/function_determinant_of">
     <rdfs:label xml:lang="en">function determinant of</rdfs:label>
+    <rdfs:label xml:lang="de">funktionaler Bestimmer von</rdfs:label>
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Function" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/function_of">
     <rdfs:label xml:lang="en">function of</rdfs:label>
+    <rdfs:label xml:lang="de">Funktion von</rdfs:label>
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_function" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/functional_item_of">
     <rdfs:label xml:lang="en">functional item of</rdfs:label>
+    <rdfs:label xml:lang="de">Funktionales Element von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Role" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/function_determinant_of" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_functional_item" />
@@ -1076,6 +1166,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/goal_of">
     <rdfs:label xml:lang="en">goal of</rdfs:label>
+    <rdfs:label xml:lang="de">Ziel von</rdfs:label>
     <skos:definition xml:lang="en">The term "goal" here refers to "final state" in (Burek, 2006).</skos:definition>
     <rdfs:domain rdf:nodeID="b36" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/function_determinant_of" />
@@ -1085,12 +1176,14 @@
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_agent" />
   <owl:InverseFunctionalProperty rdf:about="https://w3id.org/gfo/base/has_boundary">
     <rdfs:label xml:lang="en">has boundary</rdfs:label>
+    <rdfs:label xml:lang="de">hat Grenze</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/boundary_of" />
   </owl:InverseFunctionalProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_categorial_part">
     <rdfs:label xml:lang="en">has categorial part</rdfs:label>
+    <rdfs:label xml:lang="de">hat kategorialen Bestandteil</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Category" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Category" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/abstract_has_part" />
@@ -1098,6 +1191,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_category">
     <rdfs:label xml:lang="en">has category</rdfs:label>
+    <rdfs:label xml:lang="de">hat Kategorie</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Ontological_layer" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Category" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/category_in_layer" />
@@ -1105,6 +1199,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_constituent_part">
     <rdfs:label xml:lang="en">has constituent part</rdfs:label>
+    <rdfs:label xml:lang="de">hat Konstituierenden Bestandteil</rdfs:label>
     <rdfs:domain rdf:nodeID="b36" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/has_proper_part" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/constituent_part_of" />
@@ -1112,6 +1207,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_function">
     <rdfs:label xml:lang="en">has function</rdfs:label>
+    <rdfs:label xml:lang="de">hat Funktion</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Individual" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Function" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/function_of" />
@@ -1119,6 +1215,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_function_determinant">
     <rdfs:label xml:lang="en">has function determinant</rdfs:label>
+    <rdfs:label xml:lang="de">hat Funktions-Bestimmer</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Function" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Individual" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/function_determinant_of" />
@@ -1126,6 +1223,7 @@
 
   <owl:FunctionalProperty rdf:about="https://w3id.org/gfo/base/has_functional_item">
     <rdfs:label xml:lang="en">has functional item</rdfs:label>
+    <rdfs:label xml:lang="de">hat funktionales Element</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Function" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Role" />
@@ -1135,6 +1233,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_goal">
     <rdfs:label xml:lang="en">has goal</rdfs:label>
+    <rdfs:label xml:lang="de">hat Ziel</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Function" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/has_function_determinant" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/goal_of" />
@@ -1142,6 +1241,7 @@
 
   <owl:FunctionalProperty rdf:about="https://w3id.org/gfo/base/has_left_time_boundary">
     <rdfs:label xml:lang="en">has left time boundary</rdfs:label>
+    <rdfs:label xml:lang="de">hat linke zeitliche Grenze</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/has_time_boundary" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/left_boundary_of" />
@@ -1149,6 +1249,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_member">
     <rdfs:label xml:lang="en">has member</rdfs:label>
+    <rdfs:label xml:lang="de">hat Mitglied</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Set" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Entity" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/member_of" />
@@ -1156,6 +1257,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_part">
     <rdfs:label xml:lang="en">has part</rdfs:label>
+    <rdfs:label xml:lang="de">hat Bestandteil</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty" />
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Concrete" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Concrete" />
@@ -1165,6 +1267,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_participant">
     <rdfs:label xml:lang="en">has participant</rdfs:label>
+    <rdfs:label xml:lang="de">hat Teilnehmer</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Occurrent" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Presential" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/participates_in" />
@@ -1172,6 +1275,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_proper_part">
     <rdfs:label xml:lang="en">has proper part</rdfs:label>
+    <rdfs:label xml:lang="de">hat angemessenen Bestandteil</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/has_part" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/proper_part_of" />
@@ -1179,6 +1283,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_requirement">
     <rdfs:label xml:lang="en">has requirement</rdfs:label>
+    <rdfs:label xml:lang="de">hat Anforderung</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Function" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/has_function_determinant" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/requirement_of" />
@@ -1186,6 +1291,7 @@
 
   <owl:FunctionalProperty rdf:about="https://w3id.org/gfo/base/has_right_time_boundary">
     <rdfs:label xml:lang="en">has right time boundary</rdfs:label>
+    <rdfs:label xml:lang="de">hat rechte zeitliche Grenze</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/has_time_boundary" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/right_boundary_of" />
@@ -1193,11 +1299,13 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_sequence_constituent">
     <rdfs:label xml:lang="en">has sequence constituent</rdfs:label>
+    <rdfs:label xml:lang="de">hat Sequenz-Konstituenten</rdfs:label>
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/sequence_constituent_of" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_spatial_boundary">
     <rdfs:label xml:lang="en">has spatial boundary</rdfs:label>
+    <rdfs:label xml:lang="de">hat räumliche Grenze</rdfs:label>
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Spatial_boundary" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/has_boundary" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/spatial_boundary_of" />
@@ -1205,6 +1313,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_time_boundary">
     <rdfs:label xml:lang="en">has time boundary</rdfs:label>
+    <rdfs:label xml:lang="de">hat zeitliche Grenze</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Chronoid" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Time_boundary" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/has_boundary" />
@@ -1213,6 +1322,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_token">
     <rdfs:label xml:lang="en">has token</rdfs:label>
+    <rdfs:label xml:lang="de">hat Zeichen</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Symbol_structure" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Token" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/instantiated_by" />
@@ -1221,6 +1331,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/has_value">
     <rdfs:label xml:lang="en">has value</rdfs:label>
+    <rdfs:label xml:lang="de">hat Wert</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Property" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Property_value" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/value_of" />
@@ -1228,6 +1339,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/instance_of">
     <rdfs:label xml:lang="en">instance of</rdfs:label>
+    <rdfs:label xml:lang="de">Instanz von</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The instantiation relation
       holds between a category and an item. It is not a relation between categories and individuals
       due to higher order categories such as "species".</skos:definition>
@@ -1238,12 +1350,14 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/instantiated_by">
     <rdfs:label xml:lang="en">instantiated by</rdfs:label>
+    <rdfs:label xml:lang="de">instanziiert von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Category" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/instance_of" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/layer_of">
     <rdfs:label xml:lang="en">layer of</rdfs:label>
+    <rdfs:label xml:lang="de">Ebene von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Ontological_layer" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Individual" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/on_layer" />
@@ -1251,6 +1365,7 @@
 
   <owl:InverseFunctionalProperty rdf:about="https://w3id.org/gfo/base/left_boundary_of">
     <rdfs:label xml:lang="en">left boundary of</rdfs:label>
+    <rdfs:label xml:lang="de">linke Grenze von</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Left boundary of a
       chronoid.</skos:definition>
@@ -1259,6 +1374,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/level_of">
     <rdfs:label xml:lang="en">level of</rdfs:label>
+    <rdfs:label xml:lang="de">Stufe von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Level" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/layer_of" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/on_level" />
@@ -1266,6 +1382,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/member_of">
     <rdfs:label xml:lang="en">member of</rdfs:label>
+    <rdfs:label xml:lang="de">Mitglied von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Entity" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Set" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_member" />
@@ -1273,6 +1390,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/necessary_for">
     <rdfs:label xml:lang="en">necessary for</rdfs:label>
+    <rdfs:label xml:lang="de">notwendig für</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Item" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Item" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/depends_on" />
@@ -1280,6 +1398,7 @@
 
   <owl:InverseFunctionalProperty rdf:about="https://w3id.org/gfo/base/occupied_by">
     <rdfs:label xml:lang="en">occupied by</rdfs:label>
+    <rdfs:label xml:lang="de">besetzt von</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Space" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Presential" />
@@ -1288,6 +1407,7 @@
 
   <owl:FunctionalProperty rdf:about="https://w3id.org/gfo/base/occupies">
     <rdfs:label xml:lang="en">occupies</rdfs:label>
+    <rdfs:label xml:lang="de">besetzen</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Presential" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Space" />
@@ -1296,13 +1416,15 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/on_layer">
     <rdfs:label xml:lang="en">on layer</rdfs:label>
+    <rdfs:label xml:lang="de">auf Stufe</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Individual" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Ontological_layer" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/layer_of" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/on_level">
-    <rdfs:label xml:lang="en">on level</rdfs:label>
+    <rdfs:label xml:lang="en">on Ebene</rdfs:label>
+    <rdfs:label xml:lang="de">auf Stufe</rdfs:label>
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Level" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/on_layer" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/level_of" />
@@ -1310,6 +1432,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/on_stratum">
     <rdfs:label xml:lang="en">on stratum</rdfs:label>
+    <rdfs:label xml:lang="de">auf der Schicht</rdfs:label>
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Stratum" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/on_layer" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/stratum_of" />
@@ -1317,6 +1440,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/part_of">
     <rdfs:label xml:lang="en">part of</rdfs:label>
+    <rdfs:label xml:lang="de">Bestandteil von</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty" />
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Concrete" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Concrete" />
@@ -1326,6 +1450,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/participates_in">
     <rdfs:label xml:lang="en">participates in</rdfs:label>
+    <rdfs:label xml:lang="de">partizipiert in</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Presential" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Occurrent" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_participant" />
@@ -1333,17 +1458,20 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/plays_role">
     <rdfs:label xml:lang="en">plays role</rdfs:label>
+    <rdfs:label xml:lang="de">spielt Rolle</rdfs:label>
     <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Role" />
   </owl:ObjectProperty>
 
   <owl:InverseFunctionalProperty rdf:about="https://w3id.org/gfo/base/projection_of">
     <rdfs:label xml:lang="en">projection of</rdfs:label>
+    <rdfs:label xml:lang="de">Projektion von</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
   </owl:InverseFunctionalProperty>
 
   <owl:FunctionalProperty rdf:about="https://w3id.org/gfo/base/projects_to">
     <rdfs:label xml:lang="en">projects to</rdfs:label>
+    <rdfs:label xml:lang="de">projiziert auf</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Occurrent" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Temporal_region" />
@@ -1352,6 +1480,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/proper_part_of">
     <rdfs:label xml:lang="en">proper part of</rdfs:label>
+    <rdfs:label xml:lang="de">angemessener Bestandteil von</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/part_of" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_proper_part" />
@@ -1359,11 +1488,13 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/realized_by">
     <rdfs:label xml:lang="en">realized by</rdfs:label>
+    <rdfs:label xml:lang="de">verwirklicht durch</rdfs:label>
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/realizes" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/realizes">
     <rdfs:label xml:lang="en">realizes</rdfs:label>
+    <rdfs:label xml:lang="de">verwirklichen</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Individual" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Function" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/realized_by" />
@@ -1371,6 +1502,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/requirement_of">
     <rdfs:label xml:lang="en">requirement of</rdfs:label>
+    <rdfs:label xml:lang="de">Anforderung von</rdfs:label>
     <skos:definition xml:lang="en">The term "requirement" here refers to "initial state" in (Burek, 2006).</skos:definition>
     <rdfs:domain rdf:nodeID="b36" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/function_determinant_of" />
@@ -1379,6 +1511,7 @@
 
   <owl:InverseFunctionalProperty rdf:about="https://w3id.org/gfo/base/right_boundary_of">
     <rdfs:label xml:lang="en">right boundary of</rdfs:label>
+    <rdfs:label xml:lang="de">rechte Grenze von</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty" />
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Right boundary of a
       chronoid.</skos:definition>
@@ -1387,12 +1520,14 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/role_of">
     <rdfs:label xml:lang="en">role of</rdfs:label>
+    <rdfs:label xml:lang="de">Rolle von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Role" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Individual" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/sequence_constituent_of">
     <rdfs:label xml:lang="en">sequence constituent of</rdfs:label>
+    <rdfs:label xml:lang="de">Sequenz-Bestandteil von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Symbol" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Symbol_sequence" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/categorial_part_of" />
@@ -1401,6 +1536,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/spatial_boundary_of">
     <rdfs:label xml:lang="en">spatial boundary of</rdfs:label>
+    <rdfs:label xml:lang="de">räumliche Grenze von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Spatial_boundary" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Space" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/boundary_of" />
@@ -1409,6 +1545,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/stratum_of">
     <rdfs:label xml:lang="en">stratum of</rdfs:label>
+    <rdfs:label xml:lang="de">Schicht von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Stratum" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/layer_of" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/on_stratum" />
@@ -1416,6 +1553,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/time_boundary_of">
     <rdfs:label xml:lang="en">time boundary of</rdfs:label>
+    <rdfs:label xml:lang="de">zeitliche Grenze von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Time_boundary" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Chronoid" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/boundary_of" />
@@ -1424,11 +1562,13 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/token_of">
     <rdfs:label xml:lang="en">token of</rdfs:label>
+    <rdfs:label xml:lang="de">Zeichen von</rdfs:label>
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_token" />
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/value_of">
     <rdfs:label xml:lang="en">value of</rdfs:label>
+    <rdfs:label xml:lang="de">Wert von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Property_value" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Property" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/has_value" />

--- a/modules/gfo-base.owl
+++ b/modules/gfo-base.owl
@@ -38,6 +38,7 @@
     <skos:definition xml:lang="en">Abstract individuals are independent from time and space (they are
       not in time and space).
       Examples: the number "2" or pi.</skos:definition>
+    <rdfs:comment xml:lang="de">Ein abstraktives Individuum ist ein Individuum und existiert unabhängig von Raum und Zeit (z.B. eine Zahl).</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Individual" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Concrete" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Space_time" />
@@ -97,6 +98,7 @@
       other entities.
       Categories are defined intensional-with-an-s. They are, therefore, closely related to
       language.</skos:definition>
+    <rdfs:comment xml:lang="de">Eine Kategorie ist eine Entität, die eine Bezeichnung trägt und durch prädikative Begriffe einer formalen bzw. natürlichen Sprache beschrieben wird. Ein prädikativer Begriff ist ein sprachlicher Ausdruck, der die Bedingungen angibt, die jede Entität erfüllen muss, wenn sie Teil der Kategorie sein soll. Ein Ausdruck ist eine geordnete Menge von Zeichen in einer Sprache (z.B. Deutsch).</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Item" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Individual" />
   </owl:Class>
@@ -140,12 +142,14 @@
       Every chronoid has exactly two extremal and
       infinitely many inner time boundaries which are
       equivalently called time-points.</skos:definition>
+    <rdfs:comment xml:lang="de">Ein Chronoid ist eine Zeit-Entität und besitzt eine zeitliche Ausdehnung (Zeitinterval) mit einem Start- und Endzeitpunkt. Weiterhin besitzt er unendlich viele Zeitpunkte, auch innere Zeitgrenzen genannt.</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Temporal_region" />
   </owl:Class>
 
   <owl:Class rdf:about="https://w3id.org/gfo/base/Concept">
     <rdfs:label xml:lang="en">Concept</rdfs:label>
     <rdfs:label xml:lang="de">Konzept</rdfs:label>
+    <rdfs:comment xml:lang="de">Ein Konzept K (B, A, V) ist eine Kategorie K und besteht aus einer Bezeichnung  B (= geordnete Menge von Zeichen), einer Menge von Ausdrücken A und einer Vorstellung im Kopf V. Ein Konzept drückt vereinfacht gesagt eine Vorstellung im Kopf durch eine Menge von Ausdrücken (und Bezeichnungen) aus. Es gibt eine wechselseitige Abhängigkeit zwischen Konzepten und Ausdrücken. Ausdrücke verwenden Konzepte, um Sätze zu bilden und Charakteristiken zu beschreiben. Konzepte wiederum fassen eine Reihe von Ausdrücken zusammen.</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Category" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Symbol_structure" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Universal" />
@@ -267,6 +271,7 @@
     <rdfs:label xml:lang="de">Entität</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Everything which exists is
       called an entity.</skos:definition>
+    <rdfs:comment xml:lang="de">Eine Entität referenziert alles, was in einer der ontologischen Ebenen existieren kann und wird eingeteilt in Kategorien und Individuen (ohne Überschneidungen).</rdfs:comment>
     <owl:unionOf rdf:parseType="Collection">
       <rdf:Description rdf:about="https://w3id.org/gfo/base/Item" />
       <rdf:Description rdf:about="https://w3id.org/gfo/base/Set" />
@@ -322,6 +327,7 @@
     <rdfs:label xml:lang="de">Individuum</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Individuals are entities
       which cannot be further instantiated.</skos:definition>
+    <rdfs:comment xml:lang="de">Ein Individuum ist ein Element und eine konkrete Ausprägung einer Kategorie (Universal, Konzept oder Symbolstruktur). Ausprägung heißt hier, dass ein Individuum eine konkrete Menge an Charakteristiken übernimmt, die die Kategorie "vorschreibt". Individuen sind in der Hierarchie nur ein Zwischenschritt und existieren nicht eigenständig.</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Item" />
     <rdfs:subClassOf>
       <owl:Class>
@@ -483,6 +489,7 @@
       have
       it as quality, and it consists of an amount of substrate, and it instantiates a persistant
       ("has identity").</skos:definition>
+    <rdfs:comment xml:lang="de">Ein materielles Objekt ist ein materieller Kontinuant und besetzt einen dreidimensionalen Raum.</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Discrete_presential" />
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -690,6 +697,7 @@
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Processes are a special
       kind of occurrent. Processes are directly in time, they have characteristics which cannot be
       captured by a collection of time boundaries.</skos:definition>
+    <rdfs:comment xml:lang="de">Ein Prozess ist eine prozessuale Entität und hat eine zeitliche Ausdehnung (= Chronoid).</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Occurrent" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Change" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/History" />
@@ -715,6 +723,7 @@
   <owl:Class rdf:about="https://w3id.org/gfo/base/Property">
     <rdfs:label xml:lang="en">Property</rdfs:label>
     <rdfs:label xml:lang="de">Eigenschaft</rdfs:label>
+    <rdfs:comment xml:lang="de">Eine Eigenschaft repräsentiert die spezifischen Charakteristiken einer Entität und lässt sich in 3 Bestandteile aufteilen. (1) Das Eigenschafts-Universal (z.B. Farbe) referenziert ein Universal. (2) Das Eigenschafts-Individuum ist eine Instanz des Eigenschafts-Universals (z.B. Blau) und ihm ist eine Menge von Wertestrukturen zugeordnet. (3) Eine Wertestruktur beschreibt mögliche Werte und wie diese in die Struktur eingeordnet werden (z.B. hexadezimale Farbwerte für ein ganz bestimmtes Blau).</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Concrete" />
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Dependent" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Relator" />
@@ -726,6 +735,7 @@
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The concept of a property
       value reflects a relationship between the property of x and the same property as exhibited by
       another entity y.</skos:definition>
+    <rdfs:comment xml:lang="de">Ein Eigenschaftswert ist einem Eigenschafts-Individuum zugeordnet und besitzt eine Menge von Wertestrukturen. Eine Wertestruktur beschreibt mögliche Werte und wie diese in die Struktur eingeordnet werden (z.B. hexadezimale Farbwerte für ein ganz bestimmtes Blau).</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Concrete" />
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Dependent" />
     <owl:equivalentClass>
@@ -754,6 +764,7 @@
   <owl:Class rdf:about="https://w3id.org/gfo/base/Relator">
     <rdfs:label xml:lang="en">Relator</rdfs:label>
     <rdfs:label xml:lang="de">Relator</rdfs:label>
+    <rdfs:comment xml:lang="de">Ein Relator ist der Kontext in einer relationalen Rolle.</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Individual" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Property" />
   </owl:Class>
@@ -761,6 +772,7 @@
   <owl:Class rdf:about="https://w3id.org/gfo/base/Role">
     <rdfs:label xml:lang="en">Role</rdfs:label>
     <rdfs:label xml:lang="de">Rolle</rdfs:label>
+    <rdfs:comment xml:lang="de">Eine Rolle ist ein Attributiv und relationale Entität, die eine Menge von Entitäten ("Spieler") im Rahmen eines Kontextes verknüpft, in denen die "Spieler" etwas tun oder repräsentieren. Handelt es sich um eine relationale Rolle, so nennt man den Kontext auch Relator.</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Concrete" />
   </owl:Class>
 
@@ -792,6 +804,7 @@
       the world. A situoid is, intuitively, a part of the
       world which is a coherent and comprehensible whole and does not need other entities in order
       to exist. Every situoid has a temporal extent and is framed by a topoid.</skos:definition>
+    <rdfs:comment xml:lang="de">Ein Situoid ist eine Zeit Entität und ist ein Teil der raum-zeitlichen Welt. Er entsteht aus einer Objektsituation, wenn alle Objekte durch die entsprechenden Prozesse ersetzt werden.</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Configuroid" />
   </owl:Class>
 
@@ -886,6 +899,7 @@
       certain kinds. Among these levels specific forms of categorial and
       existential dependencies hold. For example, a mental entity requires
       an animate material object as its existential bearer.</skos:definition>
+    <rdfs:comment xml:lang="de">Unsere Realität lässt sich in 4 ontologische Ebenen (auch Strata genannt) einteilen, in denen alles uns Bekannte existiert. Die 4 Ontologischen Ebenen sind die materielle Ebene (Raum-Zeit), geistige Ebene (im Kopf eines Menschen), ideelle Ebene (Bereich der Ideen) und soziale Ebene (u.a. unsere Beziehungen).</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Ontological_layer" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Level" />
   </owl:Class>
@@ -917,6 +931,7 @@
   <owl:Class rdf:about="https://w3id.org/gfo/base/Symbol_structure">
     <rdfs:label xml:lang="en">Symbol structure</rdfs:label>
     <rdfs:label xml:lang="de">Symbolstruktur</rdfs:label>
+    <rdfs:comment xml:lang="de">Eine Symbolstruktur ist eine Kategorie und besteht aus einer geordneten Menge an einzelnen Symbolen. Jedes Symbol wird durch ein Zeichen (engl. Token) instanziiert und damit in der materiellen Ebene präsent, z.B. die Buchstaben auf einer ausgedruckten A4-Seite.</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Category" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Concept" />
     <owl:disjointWith rdf:resource="https://w3id.org/gfo/base/Universal" />
@@ -947,6 +962,7 @@
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Time boundaries depend on a
       chronoids (i.e. they have no independent
       existence) and can coincide.</skos:definition>
+    <rdfs:comment xml:lang="de">Eine zeitliche Grenze ist eine Zeit-Entität und markiert einen konkreten Zeitpunkt.</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Time" />
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -982,6 +998,7 @@
     <rdfs:label xml:lang="de">Universal</rdfs:label>
     <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Universals are immanent
       universals. They exist in re.</skos:definition>
+    <rdfs:comment xml:lang="de">Ein Universal ist eine Kategorie und hat eine, von einem Betrachter unabhängige, objektive Existenz in der realen Welt. Weiterhin ist sie mit einer Invarianz der materiellen Ebene verbunden und ist etwas Abstraktes, das Dingen innewohnt.</rdfs:comment>
     <rdfs:subClassOf rdf:resource="https://w3id.org/gfo/base/Category" />
     <rdfs:subClassOf>
       <owl:Restriction>

--- a/modules/gfo-base.owl
+++ b/modules/gfo-base.owl
@@ -1357,7 +1357,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/layer_of">
     <rdfs:label xml:lang="en">layer of</rdfs:label>
-    <rdfs:label xml:lang="de">Ebene von</rdfs:label>
+    <rdfs:label xml:lang="de">Bereich von</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Ontological_layer" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Individual" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/on_layer" />
@@ -1416,7 +1416,7 @@
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/on_layer">
     <rdfs:label xml:lang="en">on layer</rdfs:label>
-    <rdfs:label xml:lang="de">auf Stufe</rdfs:label>
+    <rdfs:label xml:lang="de">im Bereich</rdfs:label>
     <rdfs:domain rdf:resource="https://w3id.org/gfo/base/Individual" />
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Ontological_layer" />
     <owl:inverseOf rdf:resource="https://w3id.org/gfo/base/layer_of" />

--- a/modules/gfo-base.owl
+++ b/modules/gfo-base.owl
@@ -1423,7 +1423,7 @@
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="https://w3id.org/gfo/base/on_level">
-    <rdfs:label xml:lang="en">on Ebene</rdfs:label>
+    <rdfs:label xml:lang="en">on level</rdfs:label>
     <rdfs:label xml:lang="de">auf Stufe</rdfs:label>
     <rdfs:range rdf:resource="https://w3id.org/gfo/base/Level" />
     <rdfs:subPropertyOf rdf:resource="https://w3id.org/gfo/base/on_layer" />


### PR DESCRIPTION
Here are German translations as stated in #41. 

As a first step I translated the name of each entity [modules/gfo-base.owl](https://github.com/Onto-Med/GFO/pull/42/files#diff-7bcfa4c3eaee6559a6e7b2e505b6f428e5cea68ac84967535453526c681e039f) (`rdfs:label`) to German to establish common ground and to avoid misunderstandings. It would be great if you could check in detail if my translations match the real meaning. Below is a list of some translations in question as a starting point.

**Translations in question:**
- Persistant => "Persistent", maybe "Etwas Beständiges" is better?
- Material Line => "Materielle Linie"?
- Individual > Abstract, Concrete, ... => Added "Individual" in each translation, such as "Abstraktes Individuum" to make it more clear
- Configuroid + Situoid reused in German because no good translation found
- Surface > "Fläche" (or is "Surface" better?)
- function determinant of => "Funktionaler Bestimmer"?
- constituent part of => "Konstituierend ist-Bestandteil-von" or better "Konstituierend ist-Bestandteil-von-Beziehung"?

**Site notes:**
- Almost all skos:definitions are "broken", e.g. containing some weird newlines. For instance: gfo:Entity skos:definition "Everything which exists is\n called an entity."

Fixes #41