### PR TITLE
README.md: move content of "Other Publications Exclusively Presenting GFO" into a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,15 @@ The following is the general form of citation for Part I, where the correspondin
 * Latest released revision: Version 1.0, Onto-Med Report Nr. 8, 01.07.2006 [PDF](https://www.onto-med.de/sites/www.onto-med.de/files/files/uploads/Publications/2006/om-report-no8.pdf)
 
 ### Other Publications Exclusively Presenting GFO
-> **Burek P, Loebe F, Herre H**. Ontology patterns for function modeling with GFO. 2023. [Provided via ResearchGate](https://www.researchgate.net/publication/378214193_Ontology_patterns_for_function_modeling_with_GFO).
 
-> **Loebe F, Burek P, Herre H**. GFO: The General Formal Ontology. AO 2022;17:71–106. https://doi.org/10.3233/AO-220264.
-
-> **Burek P, Loebe F, Herre H**. Towards GFO 2.0: Architecture, Modules and Applications. In: Brodaric B, Neuhaus F, editors. Frontiers in Artificial Intelligence and Applications, IOS Press; 2020. https://doi.org/10.3233/FAIA200658.
-
-> **Herre H**. General Formal Ontology (GFO): A Foundational Ontology for Conceptual Modelling. In: Poli R, Healy M, Kameas A, editors. Theory and Applications of Ontology: Computer Applications, Dordrecht: Springer Netherlands; 2010, p. 297–345. https://doi.org/10.1007/978-90-481-8847-5_14.
-
-> **Heller B, Herre H**. Ontological Categories in GOL. Axiomathes 2004;14:57–76. https://doi.org/10.1023/B:AXIO.0000006788.44025.49.
-
-> **Heller B, Herre H**. Formal Ontology and Principles of GOL. Onto-Med Report Nr. 1. Research Group Ontologies in Medicine (Onto-Med), University of Leipzig.
+| Year | Title                                                                           | Authors                      | Notes                                                                                                                                                                                                        |
+|------|---------------------------------------------------------------------------------|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2023 | Ontology patterns for function modeling with GFO.                               | Burek P., Loebe F., Herre H. | [Provided via ResearchGate](https://www.researchgate.net/publication/378214193_Ontology_patterns_for_function_modeling_with_GFO)                                                                             |
+| 2022 | GFO: The General Formal Ontology                                                | Loebe F., Burek P., Herre H. | AO 2022;17:71–106. https://doi.org/10.3233/AO-220264                                                                                                                                                         |
+| 2020 | Towards GFO 2.0: Architecture, Modules and Applications                         | Burek P., Loebe F., Herre H. | In: Brodaric B, Neuhaus F, editors. Frontiers in Artificial Intelligence and Applications, IOS Press; 2020. https://doi.org/10.3233/FAIA200658                                                               |
+| 2010 | General Formal Ontology (GFO): A Foundational Ontology for Conceptual Modelling | Herre H.                     | In: Poli R, Healy M, Kameas A, editors. Theory and Applications of Ontology: Computer Applications, Dordrecht: Springer Netherlands; 2010, p. 297–345. https://doi.org/10.1007/978-90-481-8847-5_14          |
+| 2004 | Ontological Categories in GOL                                                   | Heller B., Herre H.          | Axiomathes 2004;14:57–76. https://doi.org/10.1023/B:AXIO.0000006788.44025.49                                                                                                                                 |
+| 2003 | Ontological Categories in GOL                                                   | Heller B., Herre H.          | [PDF](https://www.academia.edu/download/31547691/heller-b-2003-a.pdf). Formal Ontology and Principles of GOL. Onto-Med Report Nr. 1. Research Group Ontologies in Medicine (Onto-Med), University of Leipzig |
 
 ### Further Documentation
 Apart from the GFO reports, we have not yet completed the work on more introductory or tutorial material. This is going to happen in the nearer future. Currently, the easiest way to access the basic categories of GFO is to view the file [gfo-light.owl](./gfo-light.owl) in an ontology editor (e.g. [Protégé](https://protege.stanford.edu)). In particular, that file provides short descriptions for each category.


### PR DESCRIPTION
Mostly the same information but put in a table. In my opinion its a better overview.

I added 2003 and a link for the last entry "Ontological Categories in GOL".