### PR TITLE
Add situation patterns+examples from JAO paper

### DIFF
--- a/modules/situation/examples/catalog-v001.xml
+++ b/modules/situation/examples/catalog-v001.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/simple" uri="../gfo-situation-simple.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/time-extended" uri="../gfo-situation-time-extended.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/object" uri="../gfo-situation-object.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/object-extended" uri="../gfo-situation-object-extended.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/presentic-simple" uri="../gfo-situation-presentic-simple.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/presentic-object" uri="../gfo-situation-presentic-object.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-attributives" uri="../gfo-situation-presentic-object-reified-presentic-attributives.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-objects" uri="../gfo-situation-presentic-object-reified-presentic-objects.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/simple-example" uri="gfo-situation-simple-example.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/time-extended-example" uri="gfo-situation-time-extended-example.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/object-example" uri="gfo-situation-object-example.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/object-extended-example" uri="gfo-situation-object-extended-example.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/presentic-simple-example" uri="gfo-situation-presentic-simple-example.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/presentic-object-example" uri="gfo-situation-presentic-object-example.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-attributives-example" uri="gfo-situation-presentic-object-reified-presentic-attributives-example.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-objects-example" uri="gfo-situation-presentic-object-reified-presentic-objects-example.ttl"/>
+    <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base=""/>
+</catalog>

--- a/modules/situation/examples/gfo-situation-object-example.ttl
+++ b/modules/situation/examples/gfo-situation-object-example.ttl
@@ -1,0 +1,175 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rio: <https://w3id.org/rio/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix rio-ex: <https://w3id.org/rio/example/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/object-example> rdf:type owl:Ontology ;
+                                                         owl:versionIRI <https://w3id.org/gfo/pattern/situation/object-example/release/2024-12-19> ;
+                                                         owl:imports <https://w3id.org/gfo/pattern/situation/object> ;
+                                                         dc:created "2024-12-11" ;
+                                                         dc:creator "Alexandr Uciteli" ,
+                                                                    "Christoph Beger" ,
+                                                                    "Frank Löbe" ,
+                                                                    "Franz Matthies" ,
+                                                                    "Heinrich Herre" ,
+                                                                    "Konrad Höffner" ,
+                                                                    "Patryk Burek" ,
+                                                                    "Ralph Schäfermeier" ;
+                                                         dc:description "GFO-object-situation-example is an example for the object design pattern for modeling object situations."@en ;
+                                                         dc:modified "2024-12-11" ;
+                                                         dc:title "General Formal Ontology (object situation pattern example)"@en ;
+                                                         terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                         bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                         vann:preferredNamespacePrefix "gfo-object-situation-example" ;
+                                                         vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/object-example" ;
+                                                         doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                         rdfs:label "GFO object situation pattern example"@en ;
+                                                         owl:versionInfo "2024-12-11" ;
+                                                         foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/rio/Patient
+rio:Patient rdf:type owl:Class ;
+            rdfs:subClassOf gfo-core:Object ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty gfo-core:hasQuality ;
+                              owl:someValuesFrom rio:PatientAge
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty gfo-core:participatesIn ;
+                              owl:someValuesFrom rio:RiskSituation
+                            ] .
+
+
+###  https://w3id.org/rio/PatientAge
+rio:PatientAge rdf:type owl:Class ;
+               rdfs:subClassOf gfo-core:Quality .
+
+
+###  https://w3id.org/rio/RiskSeverity
+rio:RiskSeverity rdf:type owl:Class ;
+                 rdfs:subClassOf gfo-core:Quality .
+
+
+###  https://w3id.org/rio/RiskSituation
+rio:RiskSituation rdf:type owl:Class ;
+                  rdfs:subClassOf :Situation ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty gfo-core:hasParticipantQuality ;
+                                    owl:someValuesFrom rio:PatientAge
+                                  ] .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://w3id.org/rio/example/highly_severe
+rio-ex:highly_severe rdf:type owl:NamedIndividual ,
+                              rio:RiskSeverity .
+
+
+###  https://w3id.org/rio/example/patient_1
+rio-ex:patient_1 rdf:type owl:NamedIndividual ,
+                          rio:Patient ;
+                 gfo-core:hasQuality <https://w3id.org/rio/example/10_months> ;
+                 gfo-core:participatesIn rio-ex:risk_sit1 .
+
+
+###  https://w3id.org/rio/example/risk_sit1
+rio-ex:risk_sit1 rdf:type owl:NamedIndividual ,
+                          rio:RiskSituation ;
+                 gfo-core:hasParticipantQuality <https://w3id.org/rio/example/10_months> ;
+                 gfo-core:hasQuality rio-ex:highly_severe .
+
+
+###  https://w3id.org/rio/example/10_months
+<https://w3id.org/rio/example/10_months> rdf:type owl:NamedIndividual ,
+                                                  rio:PatientAge .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/examples/gfo-situation-object-extended-example.ttl
+++ b/modules/situation/examples/gfo-situation-object-extended-example.ttl
@@ -205,7 +205,9 @@ nav:person_1 rdf:type owl:NamedIndividual ,
 
 ###  https://example.org/surgical-navigation-situation/person_2
 nav:person_2 rdf:type owl:NamedIndividual ,
-                      nav:Person .
+                      nav:Person ;
+             gfo-core:hasQuality nav:surgeon ;
+             gfo-core:plays nav:operator_1 .
 
 
 ###  https://example.org/surgical-navigation-situation/person_3
@@ -222,9 +224,7 @@ nav:surgeon rdf:type owl:NamedIndividual ,
 
 ###  https://example.org/surgical-navigation-situation/surgery_1
 nav:surgery_1 rdf:type owl:NamedIndividual ,
-                       nav:Surgery ;
-              gfo-core:hasQuality nav:surgeon ;
-              gfo-core:plays nav:operator_1 .
+                       nav:Surgery .
 
 
 ###  https://example.org/surgical-navigation-situation/10_months

--- a/modules/situation/examples/gfo-situation-object-extended-example.ttl
+++ b/modules/situation/examples/gfo-situation-object-extended-example.ttl
@@ -1,0 +1,240 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix nav: <https://example.org/surgical-navigation-situation/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/object-extended-example> rdf:type owl:Ontology ;
+                                                                  owl:versionIRI <https://w3id.org/gfo/pattern/situation/object-extended-example/release/2024-12-19> ;
+                                                                  owl:imports <https://w3id.org/gfo/pattern/situation/object-extended> ;
+                                                                  dc:created "2024-12-11" ;
+                                                                  dc:creator "Alexandr Uciteli" ,
+                                                                             "Christoph Beger" ,
+                                                                             "Frank Löbe" ,
+                                                                             "Franz Matthies" ,
+                                                                             "Heinrich Herre" ,
+                                                                             "Konrad Höffner" ,
+                                                                             "Patryk Burek" ,
+                                                                             "Ralph Schäfermeier" ;
+                                                                  dc:description "GFO-object-extended-situation-example is an example for the object-extended design pattern for modeling extended object situations."@en ;
+                                                                  dc:modified "2024-12-11" ;
+                                                                  dc:title "General Formal Ontology (extended object situation pattern example)"@en ;
+                                                                  terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                                  bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                  vann:preferredNamespacePrefix "gfo-object-extended-situation-example" ;
+                                                                  vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/object-extended-example" ;
+                                                                  doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                                  rdfs:label "GFO object-extended situation pattern example"@en ;
+                                                                  owl:versionInfo "2024-12-11" ;
+                                                                  foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://example.org/surgical-navigation-situation/BirthDate
+nav:BirthDate rdf:type owl:Class ;
+              rdfs:subClassOf gfo-core:Quality .
+
+
+###  https://example.org/surgical-navigation-situation/JobProfile
+nav:JobProfile rdf:type owl:Class ;
+               rdfs:subClassOf gfo-core:Quality .
+
+
+###  https://example.org/surgical-navigation-situation/Operator
+nav:Operator rdf:type owl:Class ;
+             rdfs:subClassOf gfo-core:Role ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty gfo-core:roleIn ;
+                               owl:someValuesFrom nav:Surgery
+                             ] .
+
+
+###  https://example.org/surgical-navigation-situation/Patient
+nav:Patient rdf:type owl:Class ;
+            rdfs:subClassOf gfo-core:Role ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty gfo-core:hasQuality ;
+                              owl:someValuesFrom nav:PatientAge
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty gfo-core:roleIn ;
+                              owl:someValuesFrom nav:Surgery
+                            ] .
+
+
+###  https://example.org/surgical-navigation-situation/PatientAge
+nav:PatientAge rdf:type owl:Class ;
+               rdfs:subClassOf gfo-core:Quality .
+
+
+###  https://example.org/surgical-navigation-situation/Person
+nav:Person rdf:type owl:Class ;
+           rdfs:subClassOf gfo-core:Object ,
+                           [ rdf:type owl:Class ;
+                             owl:unionOf ( [ rdf:type owl:Restriction ;
+                                             owl:onProperty gfo-core:plays ;
+                                             owl:someValuesFrom nav:Operator
+                                           ]
+                                           [ rdf:type owl:Restriction ;
+                                             owl:onProperty gfo-core:plays ;
+                                             owl:someValuesFrom nav:Patient
+                                           ]
+                                         )
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty gfo-core:hasQuality ;
+                             owl:someValuesFrom nav:BirthDate
+                           ] .
+
+
+###  https://example.org/surgical-navigation-situation/Surgery
+nav:Surgery rdf:type owl:Class ;
+            rdfs:subClassOf :Situation .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://example.org/surgical-navigation-situation/operator_1
+nav:operator_1 rdf:type owl:NamedIndividual ,
+                        nav:Operator ;
+               gfo-core:roleIn nav:surgery_1 .
+
+
+###  https://example.org/surgical-navigation-situation/operator_2
+nav:operator_2 rdf:type owl:NamedIndividual ,
+                        nav:Operator ;
+               gfo-core:roleIn nav:surgery_1 .
+
+
+###  https://example.org/surgical-navigation-situation/patient_1
+nav:patient_1 rdf:type owl:NamedIndividual ,
+                       nav:Patient ;
+              gfo-core:hasQuality <https://example.org/surgical-navigation-situation/10_months> ;
+              gfo-core:roleIn nav:surgery_1 .
+
+
+###  https://example.org/surgical-navigation-situation/person_1
+nav:person_1 rdf:type owl:NamedIndividual ,
+                      nav:Person ;
+             gfo-core:hasQuality <https://example.org/surgical-navigation-situation/10-07-2024> ;
+             gfo-core:plays nav:patient_1 .
+
+
+###  https://example.org/surgical-navigation-situation/person_2
+nav:person_2 rdf:type owl:NamedIndividual ,
+                      nav:Person .
+
+
+###  https://example.org/surgical-navigation-situation/person_3
+nav:person_3 rdf:type owl:NamedIndividual ,
+                      nav:Person ;
+             gfo-core:hasQuality nav:surgeon ;
+             gfo-core:plays nav:operator_2 .
+
+
+###  https://example.org/surgical-navigation-situation/surgeon
+nav:surgeon rdf:type owl:NamedIndividual ,
+                     nav:JobProfile .
+
+
+###  https://example.org/surgical-navigation-situation/surgery_1
+nav:surgery_1 rdf:type owl:NamedIndividual ,
+                       nav:Surgery ;
+              gfo-core:hasQuality nav:surgeon ;
+              gfo-core:plays nav:operator_1 .
+
+
+###  https://example.org/surgical-navigation-situation/10_months
+<https://example.org/surgical-navigation-situation/10_months> rdf:type owl:NamedIndividual ,
+                                                                       nav:PatientAge .
+
+
+###  https://example.org/surgical-navigation-situation/10-07-2024
+<https://example.org/surgical-navigation-situation/10-07-2024> rdf:type owl:NamedIndividual ,
+                                                                        nav:BirthDate .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/examples/gfo-situation-presentic-object-example.ttl
+++ b/modules/situation/examples/gfo-situation-presentic-object-example.ttl
@@ -1,0 +1,170 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@prefix rio: <https://w3id.org/rio/> .
+@prefix rio-ex: <https://w3id.org/rio/example/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/presentic-object-example> rdf:type owl:Ontology ;
+                                                                   owl:versionIRI <https://w3id.org/gfo/pattern/situation/presentic-object-example/release/2024-12-19> ;
+                                                                   owl:imports <https://w3id.org/gfo/pattern/situation/presentic-object> ;
+                                                                   dc:created "2024-12-11" ;
+                                                                   dc:creator "Alexandr Uciteli" ,
+                                                                              "Christoph Beger" ,
+                                                                              "Frank Löbe" ,
+                                                                              "Franz Matthies" ,
+                                                                              "Heinrich Herre" ,
+                                                                              "Konrad Höffner" ,
+                                                                              "Patryk Burek" ,
+                                                                              "Ralph Schäfermeier" ;
+                                                                   dc:description "GFO-presentic-object-situation-example is an example for the presentic-object design pattern for modeling presentic object situations."@en ;
+                                                                   dc:modified "2024-12-11" ;
+                                                                   dc:title "General Formal Ontology (presentic object situation pattern example)"@en ;
+                                                                   terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                                   bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                   vann:preferredNamespacePrefix "gfo-presentic-object-situation-example" ;
+                                                                   vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object-example" ;
+                                                                   doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                                   rdfs:label "GFO presentic-object situation pattern example"@en ;
+                                                                   owl:versionInfo "2024-12-11" ;
+                                                                   foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/rio/PatientAge
+<https://w3id.org/rio/PatientAge> rdf:type owl:Class ;
+                                  rdfs:subClassOf gfo-core:Attributive .
+
+
+###  https://w3id.org/rio/Patient
+<https://w3id.org/rio/Patient> rdf:type owl:Class ;
+                                       rdfs:subClassOf gfo-core:Object .
+
+
+###  https://w3id.org/rio/example/RiskSituationSnapshot
+<https://w3id.org/rio/example/RiskSituationSnapshot> rdf:type owl:Class ;
+                                                     rdfs:subClassOf :PresenticSituation .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://w3id.org/rio/example/patient_1
+<https://w3id.org/rio/example/patient_1> rdf:type owl:NamedIndividual ,
+                                                  <https://w3id.org/rio/Patient> ;
+                                         gfo-core:hasAttributive <https://w3id.org/rio/example/10_months> ;
+                                         gfo-core:hasTime <https://w3id.org/rio/example/patient_1_lifespan> ;
+                                         gfo-core:participatesIn <https://w3id.org/rio/example/risk_sit1_snapshot> .
+
+
+###  https://w3id.org/rio/example/patient_1_lifespan
+<https://w3id.org/rio/example/patient_1_lifespan> rdf:type owl:NamedIndividual ,
+                                                           gfo-core:TimeInterval .
+
+
+###  https://w3id.org/rio/example/risk_sit1_snapshot
+<https://w3id.org/rio/example/risk_sit1_snapshot> rdf:type owl:NamedIndividual ,
+                                                           <https://w3id.org/rio/example/RiskSituationSnapshot> ;
+                                                  gfo-core:hasPart <https://w3id.org/rio/example/10_months> ;
+                                                  gfo-core:hasTime <https://w3id.org/rio/example/timepoint_1> .
+
+
+###  https://w3id.org/rio/example/risk_sit_1_timespan
+<https://w3id.org/rio/example/risk_sit_1_timespan> rdf:type owl:NamedIndividual ,
+                                                            gfo-core:TimeInterval .
+
+
+###  https://w3id.org/rio/example/timepoint_1
+<https://w3id.org/rio/example/timepoint_1> rdf:type owl:NamedIndividual ,
+                                                    gfo-core:TimePoint .
+
+
+###  https://w3id.org/rio/example/10_months
+<https://w3id.org/rio/example/10_months> rdf:type owl:NamedIndividual ,
+                                                  <https://w3id.org/rio/PatientAge> ;
+                                         gfo-core:hasTime <https://w3id.org/rio/example/risk_sit_1_timespan> .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/examples/gfo-situation-presentic-object-reified-presentic-attributives-example.ttl
+++ b/modules/situation/examples/gfo-situation-presentic-object-reified-presentic-attributives-example.ttl
@@ -1,0 +1,165 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@prefix rio: <https://w3id.org/rio/> .
+@prefix rio-ex: <https://w3id.org/rio/example/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-attributives-example> rdf:type owl:Ontology ;
+                                                                                                  owl:versionIRI <https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-attributives-example/release/2024-12-19> ;
+                                                                                                  owl:imports <https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-attributives> ;
+                                                                                                  dc:created "2024-12-11" ;
+                                                                                                  dc:creator "Alexandr Uciteli" ,
+                                                                                                             "Christoph Beger" ,
+                                                                                                             "Frank Löbe" ,
+                                                                                                             "Franz Matthies" ,
+                                                                                                             "Heinrich Herre" ,
+                                                                                                             "Konrad Höffner" ,
+                                                                                                             "Patryk Burek" ,
+                                                                                                             "Ralph Schäfermeier" ;
+                                                                                                  dc:description "GFO-presentic-object-reified-presentic-attributives-situation-example is an example for the presentic-object-reified-presentic-attributives design pattern for modeling presentic-object-reified-presentic-attributives situations."@en ;
+                                                                                                  dc:modified "2024-12-11" ;
+                                                                                                  dc:title "General Formal Ontology (presentic-object-reified-presentic-attributives situation pattern example)"@en ;
+                                                                                                  terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                                                                  bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                                                  vann:preferredNamespacePrefix "gfo-presentic-object-reified-presentic-attributives-situation-example" ;
+                                                                                                  vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-attributives-example" ;
+                                                                                                  doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                                                                  rdfs:label "GFO presentic-object-reified-presentic-attributives situation pattern example"@en ;
+                                                                                                  owl:versionInfo "2024-12-11" ;
+                                                                                                  foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/rio/PatientAgeSnapshot
+<https://w3id.org/rio/PatientAgeSnapshot> rdf:type owl:Class ;
+                                          rdfs:subClassOf gfo-core:PresenticAttributive .
+
+
+###  https://w3id.org/rio/Patient
+<https://w3id.org/rio/Patient> rdf:type owl:Class ;
+                                       rdfs:subClassOf gfo-core:Object .
+
+
+###  https://w3id.org/rio/example/RiskSituationSnapshot
+<https://w3id.org/rio/example/RiskSituationSnapshot> rdf:type owl:Class ;
+                                                     rdfs:subClassOf :PresenticSituation .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://w3id.org/rio/example/patient_1
+<https://w3id.org/rio/example/patient_1> rdf:type owl:NamedIndividual ,
+                                                  <https://w3id.org/rio/Patient> ;
+                                         gfo-core:hasAttributive <https://w3id.org/rio/example/10_months_presentic> ;
+                                         gfo-core:hasTime <https://w3id.org/rio/example/patient_1_lifespan> ;
+                                         gfo-core:participatesIn <https://w3id.org/rio/example/risk_sit1_snapshot> .
+
+
+###  https://w3id.org/rio/example/patient_1_lifespan
+<https://w3id.org/rio/example/patient_1_lifespan> rdf:type owl:NamedIndividual ,
+                                                           gfo-core:TimeInterval .
+
+
+###  https://w3id.org/rio/example/risk_sit1_snapshot
+<https://w3id.org/rio/example/risk_sit1_snapshot> rdf:type owl:NamedIndividual ,
+                                                           <https://w3id.org/rio/example/RiskSituationSnapshot> ;
+                                                  gfo-core:hasPart <https://w3id.org/rio/example/10_months_presentic> ;
+                                                  gfo-core:hasTime <https://w3id.org/rio/example/timepoint_1> .
+
+
+###  https://w3id.org/rio/example/timepoint_1
+<https://w3id.org/rio/example/timepoint_1> rdf:type owl:NamedIndividual ,
+                                                    gfo-core:TimePoint .
+
+
+###  https://w3id.org/rio/example/10_months_presentic
+<https://w3id.org/rio/example/10_months_presentic> rdf:type owl:NamedIndividual ,
+                                                            <https://w3id.org/rio/PatientAgeSnapshot> ;
+                                                   gfo-core:hasTime <https://w3id.org/rio/example/timepoint_1> .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/examples/gfo-situation-presentic-object-reified-presentic-objects-example.ttl
+++ b/modules/situation/examples/gfo-situation-presentic-object-reified-presentic-objects-example.ttl
@@ -1,0 +1,177 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rio: <https://w3id.org/rio/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix rio-ex: <https://w3id.org/rio/example/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-objects-example> rdf:type owl:Ontology ;
+                                                                                             owl:versionIRI <https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-objects-example/release/2024-12-19> ;
+                                                                                             owl:imports <https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-objects> ;
+                                                                                             dc:created "2024-12-11" ;
+                                                                                             dc:creator "Alexandr Uciteli" ,
+                                                                                                        "Christoph Beger" ,
+                                                                                                        "Frank Löbe" ,
+                                                                                                        "Franz Matthies" ,
+                                                                                                        "Heinrich Herre" ,
+                                                                                                        "Konrad Höffner" ,
+                                                                                                        "Patryk Burek" ,
+                                                                                                        "Ralph Schäfermeier" ;
+                                                                                             dc:description "GFO-presentic-object-reified-presentic-objects-situation-example is an example for the presentic-object-reified-presentic-objects design pattern for modeling presentic-object-reified-presentic-objects situations."@en ;
+                                                                                             dc:modified "2024-12-11" ;
+                                                                                             dc:title "General Formal Ontology (presentic-object-reified-presentic-objects situation pattern example)"@en ;
+                                                                                             terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                                                             bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                                             vann:preferredNamespacePrefix "gfo-presentic-object-reified-presentic-objects-situation-example" ;
+                                                                                             vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-objects-example" ;
+                                                                                             doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                                                             rdfs:label "GFO presentic-object-reified-presentic-objects situation pattern example"@en ;
+                                                                                             owl:versionInfo "2024-12-11" ;
+                                                                                             foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/rio/PatientAgeSnapshot
+rio:PatientAgeSnapshot rdf:type owl:Class ;
+                       rdfs:subClassOf gfo-core:PresenticAttributive .
+
+
+###  https://w3id.org/rio/PatientSnapshot
+rio:PatientSnapshot rdf:type owl:Class ;
+                    rdfs:subClassOf gfo-core:PresenticObject .
+
+
+###  https://w3id.org/rio/Patient
+rio-ex:Patient rdf:type owl:Class ;
+               rdfs:subClassOf gfo-core:Object .
+
+
+###  https://w3id.org/rio/example/RiskSituationSnapshot
+rio-ex:RiskSituationSnapshot rdf:type owl:Class ;
+                             rdfs:subClassOf :PresenticSituation .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://w3id.org/rio/example/patient_1
+rio-ex:patient_1 rdf:type owl:NamedIndividual ,
+                          rio-ex:Patient ;
+                 gfo-core:hasTime rio-ex:patient_1_lifespan .
+
+
+###  https://w3id.org/rio/example/patient_1_lifespan
+rio-ex:patient_1_lifespan rdf:type owl:NamedIndividual ,
+                                   gfo-core:TimeInterval .
+
+
+###  https://w3id.org/rio/example/patient_1_snapshot
+rio-ex:patient_1_snapshot rdf:type owl:NamedIndividual ,
+                                   rio:PatientSnapshot ;
+                          gfo-core:hasAttributive <https://w3id.org/rio/example/10_months_presentic> ;
+                          gfo-core:hasTime rio-ex:timepoint_1 ;
+                          gfo-core:participatesIn rio-ex:risk_sit1_snapshot ;
+                          gfo-core:snapshotOf rio-ex:patient_1 .
+
+
+###  https://w3id.org/rio/example/risk_sit1_snapshot
+rio-ex:risk_sit1_snapshot rdf:type owl:NamedIndividual ,
+                                   rio-ex:RiskSituationSnapshot ;
+                          gfo-core:hasPart <https://w3id.org/rio/example/10_months_presentic> ;
+                          gfo-core:hasTime rio-ex:timepoint_1 .
+
+
+###  https://w3id.org/rio/example/timepoint_1
+rio-ex:timepoint_1 rdf:type owl:NamedIndividual ,
+                            gfo-core:TimePoint .
+
+
+###  https://w3id.org/rio/example/10_months_presentic
+<https://w3id.org/rio/example/10_months_presentic> rdf:type owl:NamedIndividual ,
+                                                            rio:PatientAgeSnapshot ;
+                                                   gfo-core:hasTime rio-ex:timepoint_1 .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/examples/gfo-situation-presentic-simple-example.ttl
+++ b/modules/situation/examples/gfo-situation-presentic-simple-example.ttl
@@ -1,0 +1,195 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rio: <https://w3id.org/rio/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix rio-ex: <https://w3id.org/rio/example/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/presentic-simple-example> rdf:type owl:Ontology ;
+                                                                   owl:versionIRI <https://w3id.org/gfo/pattern/situation/presentic-simple-example/release/2024-12-19> ;
+                                                                   owl:imports <https://w3id.org/gfo/pattern/situation/presentic-simple> ;
+                                                                   dc:created "2024-12-11" ;
+                                                                   dc:creator "Alexandr Uciteli" ,
+                                                                              "Christoph Beger" ,
+                                                                              "Frank Löbe" ,
+                                                                              "Franz Matthies" ,
+                                                                              "Heinrich Herre" ,
+                                                                              "Konrad Höffner" ,
+                                                                              "Patryk Burek" ,
+                                                                              "Ralph Schäfermeier" ;
+                                                                   dc:description "GFO-presentic-simple-situation-example is an example for the presentic-simple design pattern for modeling simple presentic situations."@en ;
+                                                                   dc:modified "2024-12-11" ;
+                                                                   dc:title "General Formal Ontology (simple presentic situation pattern example)"@en ;
+                                                                   terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                                   bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                   vann:preferredNamespacePrefix "gfo-presentic-simple-situation-example" ;
+                                                                   vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-simple-example" ;
+                                                                   doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                                   rdfs:label "GFO presentic-simple situation pattern example"@en ;
+                                                                   owl:versionInfo "2024-12-11" ;
+                                                                   foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/rio/GroupRiskSituation
+rio:GroupRiskSituation rdf:type owl:Class ;
+                       rdfs:subClassOf :PresenticSituation ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty gfo-core:hasPart ;
+                                         owl:someValuesFrom rio:RiskSituation
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty gfo-core:hasQuality ;
+                                         owl:someValuesFrom rio:NumberOfPatients
+                                       ] .
+
+
+###  https://w3id.org/rio/NumberOfPatients
+rio:NumberOfPatients rdf:type owl:Class ;
+                     rdfs:subClassOf gfo-core:Quality .
+
+
+###  https://w3id.org/rio/PatientAge
+rio:PatientAge rdf:type owl:Class ;
+               rdfs:subClassOf gfo-core:Quality .
+
+
+###  https://w3id.org/rio/RiskSeverity
+rio:RiskSeverity rdf:type owl:Class ;
+                 rdfs:subClassOf gfo-core:Quality .
+
+
+###  https://w3id.org/rio/RiskSituation
+rio:RiskSituation rdf:type owl:Class ;
+                  rdfs:subClassOf :PresenticSituation ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty gfo-core:hasParticipantQuality ;
+                                    owl:someValuesFrom rio:PatientAge
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty gfo-core:hasQuality ;
+                                    owl:someValuesFrom rio:RiskSeverity
+                                  ] .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://w3id.org/rio/example/highly_severe
+rio-ex:highly_severe rdf:type owl:NamedIndividual ,
+                              rio:RiskSeverity .
+
+
+###  https://w3id.org/rio/example/risk_sit1
+rio-ex:risk_sit1 rdf:type owl:NamedIndividual ,
+                          rio:RiskSituation ;
+                 gfo-core:hasParticipantQuality <https://w3id.org/rio/example/10_months> ;
+                 gfo-core:hasQuality rio-ex:highly_severe ;
+                 gfo-core:hasTime rio-ex:timepoint_1 .
+
+
+###  https://w3id.org/rio/example/risk_sit2
+rio-ex:risk_sit2 rdf:type owl:NamedIndividual ,
+                          rio:GroupRiskSituation ;
+                 gfo-core:hasPart rio-ex:risk_sit1 ;
+                 gfo-core:hasQuality <https://w3id.org/rio/example/7> .
+
+
+###  https://w3id.org/rio/example/timepoint_1
+rio-ex:timepoint_1 rdf:type owl:NamedIndividual ,
+                            gfo-core:TimePoint .
+
+
+###  https://w3id.org/rio/example/10_months
+<https://w3id.org/rio/example/10_months> rdf:type owl:NamedIndividual ,
+                                                  rio:PatientAge .
+
+
+###  https://w3id.org/rio/example/7
+<https://w3id.org/rio/example/7> rdf:type owl:NamedIndividual ,
+                                          rio:NumberOfPatients .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/examples/gfo-situation-simple-example.ttl
+++ b/modules/situation/examples/gfo-situation-simple-example.ttl
@@ -1,0 +1,189 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rio: <https://w3id.org/rio/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix rio-ex: <https://w3id.org/rio/example/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/simple-example> rdf:type owl:Ontology ;
+                                                         owl:versionIRI <https://w3id.org/gfo/pattern/situation/simple-example/release/2024-12-19> ;
+                                                         owl:imports <https://w3id.org/gfo/pattern/situation/simple> ;
+                                                         dc:created "2024-12-11" ;
+                                                         dc:creator "Alexandr Uciteli" ,
+                                                                    "Christoph Beger" ,
+                                                                    "Frank Löbe" ,
+                                                                    "Franz Matthies" ,
+                                                                    "Heinrich Herre" ,
+                                                                    "Konrad Höffner" ,
+                                                                    "Patryk Burek" ,
+                                                                    "Ralph Schäfermeier" ;
+                                                         dc:description "GFO-simple-situation-example is an example for the simple design pattern for modeling simple situations."@en ;
+                                                         dc:modified "2024-12-11" ;
+                                                         dc:title "General Formal Ontology (simple situation pattern example)"@en ;
+                                                         terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                         bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                         vann:preferredNamespacePrefix "gfo-simple-situation-example" ;
+                                                         vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/simple-example" ;
+                                                         doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                         rdfs:label "GFO simple situation pattern example"@en ;
+                                                         owl:versionInfo "2024-12-11" ;
+                                                         foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/rio/GroupRiskSituation
+rio:GroupRiskSituation rdf:type owl:Class ;
+                       rdfs:subClassOf :Situation ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty gfo-core:hasPart ;
+                                         owl:someValuesFrom rio:RiskSituation
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty gfo-core:hasQuality ;
+                                         owl:someValuesFrom rio:NumberOfPatients
+                                       ] .
+
+
+###  https://w3id.org/rio/NumberOfPatients
+rio:NumberOfPatients rdf:type owl:Class ;
+                     rdfs:subClassOf gfo-core:Quality .
+
+
+###  https://w3id.org/rio/PatientAge
+rio:PatientAge rdf:type owl:Class ;
+               rdfs:subClassOf gfo-core:Quality .
+
+
+###  https://w3id.org/rio/RiskSeverity
+rio:RiskSeverity rdf:type owl:Class ;
+                 rdfs:subClassOf gfo-core:Quality .
+
+
+###  https://w3id.org/rio/RiskSituation
+rio:RiskSituation rdf:type owl:Class ;
+                  rdfs:subClassOf :Situation ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty gfo-core:hasParticipantQuality ;
+                                    owl:someValuesFrom rio:PatientAge
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty gfo-core:hasQuality ;
+                                    owl:someValuesFrom rio:RiskSeverity
+                                  ] .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://w3id.org/rio/example/highly_severe
+rio-ex:highly_severe rdf:type owl:NamedIndividual ,
+                              rio:RiskSeverity .
+
+
+###  https://w3id.org/rio/example/risk_sit1
+rio-ex:risk_sit1 rdf:type owl:NamedIndividual ,
+                          rio:RiskSituation ;
+                 gfo-core:hasParticipantQuality <https://w3id.org/rio/example/10_months> ;
+                 gfo-core:hasQuality rio-ex:highly_severe .
+
+
+###  https://w3id.org/rio/example/risk_sit2
+rio-ex:risk_sit2 rdf:type owl:NamedIndividual ,
+                          rio:GroupRiskSituation ;
+                 gfo-core:hasPart rio-ex:risk_sit1 ;
+                 gfo-core:hasQuality <https://w3id.org/rio/example/7> .
+
+
+###  https://w3id.org/rio/example/10_months
+<https://w3id.org/rio/example/10_months> rdf:type owl:NamedIndividual ,
+                                                  rio:PatientAge .
+
+
+###  https://w3id.org/rio/example/7
+<https://w3id.org/rio/example/7> rdf:type owl:NamedIndividual ,
+                                          rio:NumberOfPatients .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/examples/gfo-situation-time-extended-example.ttl
+++ b/modules/situation/examples/gfo-situation-time-extended-example.ttl
@@ -1,0 +1,207 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rio: <https://w3id.org/rio/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix rio-ex: <https://w3id.org/rio/example/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/time-extended-example> rdf:type owl:Ontology ;
+                                                                owl:versionIRI <https://w3id.org/gfo/pattern/situation/time-extended-example/release/2024-12-19> ;
+                                                                owl:imports <https://w3id.org/gfo/pattern/situation/time-extended> ;
+                                                                dc:created "2024-12-11" ;
+                                                                dc:creator "Alexandr Uciteli" ,
+                                                                           "Christoph Beger" ,
+                                                                           "Frank Löbe" ,
+                                                                           "Franz Matthies" ,
+                                                                           "Heinrich Herre" ,
+                                                                           "Konrad Höffner" ,
+                                                                           "Patryk Burek" ,
+                                                                           "Ralph Schäfermeier" ;
+                                                                dc:description "GFO-time-extended-situation-example is an example for the time-extended design pattern for modeling time-extended situations."@en ;
+                                                                dc:modified "2024-12-11" ;
+                                                                dc:title "General Formal Ontology (time-extended situation pattern example)"@en ;
+                                                                terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                                bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                vann:preferredNamespacePrefix "gfo-time-extended-situation-example" ;
+                                                                vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/time-extended-example" ;
+                                                                doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                                rdfs:label "GFO time-extended situation pattern example"@en ;
+                                                                owl:versionInfo "2024-12-11" ;
+                                                                foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/rio/RiskSeverity
+rio:RiskSeverity rdf:type owl:Class ;
+                 rdfs:subClassOf gfo-core:Attributive .
+
+
+###  https://w3id.org/rio/RiskSituation
+rio:RiskSituation rdf:type owl:Class ;
+                  rdfs:subClassOf :Situation ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty gfo-core:hasQuality ;
+                                    owl:someValuesFrom rio:RiskSeverity
+                                  ] .
+
+
+###  https://w3id.org/rio/Patient
+rio-ex:Patient rdf:type owl:Class ;
+               rdfs:subClassOf gfo-core:Object .
+
+
+###  https://w3id.org/rio/example/PatientSnapshot
+rio-ex:PatientSnapshot rdf:type owl:Class ;
+                       rdfs:subClassOf gfo-core:PresenticObject .
+
+
+###  https://w3id.org/rio/example/RiskSeveritySnapshot
+rio-ex:RiskSeveritySnapshot rdf:type owl:Class ;
+                            rdfs:subClassOf gfo-core:PresenticAttributive .
+
+
+###  https://w3id.org/rio/example/RiskSituationSnapshot
+rio-ex:RiskSituationSnapshot rdf:type owl:Class ;
+                             rdfs:subClassOf :PresenticSituation .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://w3id.org/rio/example/highly_severe
+rio-ex:highly_severe rdf:type owl:NamedIndividual ,
+                              rio:RiskSeverity ;
+                     gfo-core:hasTime rio-ex:timeinterval_1 .
+
+
+###  https://w3id.org/rio/example/highly_severe_presentic
+rio-ex:highly_severe_presentic rdf:type owl:NamedIndividual ,
+                                        rio-ex:RiskSeveritySnapshot ;
+                               gfo-core:hasTime rio-ex:timepoint_1 ;
+                               gfo-core:snapshotOf rio-ex:highly_severe .
+
+
+###  https://w3id.org/rio/example/patient_1
+rio-ex:patient_1 rdf:type owl:NamedIndividual ,
+                          rio-ex:Patient ;
+                 gfo-core:hasTime rio-ex:timeinterval_1 ;
+                 gfo-core:participatesIn rio-ex:risk_sit1 .
+
+
+###  https://w3id.org/rio/example/patient_1_snapshot
+rio-ex:patient_1_snapshot rdf:type owl:NamedIndividual ,
+                                   rio-ex:PatientSnapshot ;
+                          gfo-core:hasTime rio-ex:timepoint_1 ;
+                          gfo-core:participatesIn rio-ex:risk_sit1_snapshot ;
+                          gfo-core:snapshotOf rio-ex:patient_1 .
+
+
+###  https://w3id.org/rio/example/risk_sit1
+rio-ex:risk_sit1 rdf:type owl:NamedIndividual ,
+                          rio:RiskSituation ;
+                 gfo-core:hasPart rio-ex:highly_severe ;
+                 gfo-core:hasTime rio-ex:timeinterval_1 ;
+                 gfo-core:hasQuality rio-ex:highly_severe .
+
+
+###  https://w3id.org/rio/example/risk_sit1_snapshot
+rio-ex:risk_sit1_snapshot rdf:type owl:NamedIndividual ,
+                                   rio-ex:RiskSituationSnapshot ;
+                          gfo-core:hasPart rio-ex:highly_severe_presentic ;
+                          gfo-core:hasTime rio-ex:timepoint_1 ;
+                          gfo-core:snapshotOf rio-ex:risk_sit1 .
+
+
+###  https://w3id.org/rio/example/timeinterval_1
+rio-ex:timeinterval_1 rdf:type owl:NamedIndividual ,
+                               gfo-core:TimeInterval .
+
+
+###  https://w3id.org/rio/example/timepoint_1
+rio-ex:timepoint_1 rdf:type owl:NamedIndividual ,
+                            gfo-core:TimePoint .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/gfo-situation-object-extended.ttl
+++ b/modules/situation/gfo-situation-object-extended.ttl
@@ -141,7 +141,7 @@ gfo-core:relatedBy rdf:type owl:ObjectProperty ;
 
 ###  https://w3id.org/gfo/core/roleIn
 gfo-core:roleIn rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf owl:topObjectProperty .
+                rdfs:label "role in"@en .
 
 
 #################################################################
@@ -210,7 +210,11 @@ gfo-core:Role rdf:type owl:Class ;
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty gfo-core:roleIn ;
                                 owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                owl:onClass gfo-core:Relator
+                                owl:onClass [ rdf:type owl:Class ;
+                                              owl:unionOf ( gfo-core:Relator
+                                                            :Situation
+                                                          )
+                                            ]
                               ] ;
               rdfs:label "Role"@en ;
               skos:definition "A role characterizes an entity—its required player—through its context (e.g., relation/relator)."@en .
@@ -218,24 +222,28 @@ gfo-core:Role rdf:type owl:Class ;
 
 ###  https://w3id.org/gfo/situation/Situation
 :Situation rdf:type owl:Class ;
-           rdfs:subClassOf _:genid6 ,
-                           _:genid8 ;
+           rdfs:subClassOf _:genid9 ,
+                           _:genid14 ;
            rdfs:comment "In line with GFO, we assume that every situation consists of at least one object that participates_in the situation."@en ;
            rdfs:label "Situation"@en ;
            skos:definition "Situations as complex entities that are comprehended as wholes"@en .
 
-_:genid6 rdf:type owl:Restriction ;
+_:genid9 rdf:type owl:Restriction ;
           owl:onProperty gfo-core:hasPart ;
-          owl:allValuesFrom :Situation .
+          owl:allValuesFrom [ rdf:type owl:Class ;
+                              owl:unionOf ( gfo-core:Attributive
+                                            :Situation
+                                          )
+                            ] .
 
-_:genid8 rdf:type owl:Restriction ;
-          owl:onProperty gfo-core:hasParticipantQuality ;
-          owl:allValuesFrom gfo-core:Quality .
+_:genid14 rdf:type owl:Restriction ;
+           owl:onProperty gfo-core:hasParticipantQuality ;
+           owl:allValuesFrom gfo-core:Quality .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource :Situation ;
    owl:annotatedProperty rdfs:subClassOf ;
-   owl:annotatedTarget _:genid6 ;
+   owl:annotatedTarget _:genid9 ;
    rdfs:comment "As opposed to PresenticSituation hasPart only PresenticSituation" ,
                 "Should this axiom be part of gfo-core?"
  ] .
@@ -243,7 +251,7 @@ _:genid8 rdf:type owl:Restriction ;
 [ rdf:type owl:Axiom ;
    owl:annotatedSource :Situation ;
    owl:annotatedProperty rdfs:subClassOf ;
-   owl:annotatedTarget _:genid8 ;
+   owl:annotatedTarget _:genid14 ;
    rdfs:comment "As opposed to PresenticSituation hasPArticipantQuality only PresenticQuality" ,
                 "Should this axiom be part of gfo-core?"
  ] .

--- a/modules/situation/gfo-situation-object-extended.ttl
+++ b/modules/situation/gfo-situation-object-extended.ttl
@@ -14,28 +14,28 @@
 @prefix gfo-core: <https://w3id.org/gfo/core/> .
 @base <https://w3id.org/gfo/situation/> .
 
-<https://w3id.org/gfo/situation/object/extended> rdf:type owl:Ontology ;
-                                                  owl:versionIRI <https://w3id.org/gfo/situation/object/extended/release/2024-12-11> ;
-                                                  dc:created "2024-12-11" ;
-                                                  dc:creator "Alexandr Uciteli" ,
-                                                             "Christoph Beger" ,
-                                                             "Frank Löbe" ,
-                                                             "Franz Matthies" ,
-                                                             "Heinrich Herre" ,
-                                                             "Konrad Höffner" ,
-                                                             "Patryk Burek" ,
-                                                             "Ralph Schäfermeier" ;
-                                                  dc:description "GFO-situation-object-extended is an ontology desing pattern for modeling extended object situations."@en ;
-                                                  dc:modified "2024-12-11" ;
-                                                  dc:title "General Formal Ontology (extended object situation pattern)"@en ;
-                                                  terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                  bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
-                                                  vann:preferredNamespacePrefix "gfo-situation-object-extended" ;
-                                                  vann:preferredNamespaceURI "https://w3id.org/gfo/situation/object/extended" ;
-                                                  doap:repository <https://github.com/Onto-Med/GFO> ;
-                                                  rdfs:label "GFO-situation-object-extended"@en ;
-                                                  owl:versionInfo "2024-12-11" ;
-                                                  foaf:homepage "https://github.com/Onto-Med/GFO" .
+<https://w3id.org/gfo/pattern/situation/object-extended> rdf:type owl:Ontology ;
+                                                          owl:versionIRI <https://w3id.org/gfo/pattern/situation/object-extended/release/2024-12-19> ;
+                                                          dc:created "2024-12-11" ;
+                                                          dc:creator "Alexandr Uciteli" ,
+                                                                     "Christoph Beger" ,
+                                                                     "Frank Löbe" ,
+                                                                     "Franz Matthies" ,
+                                                                     "Heinrich Herre" ,
+                                                                     "Konrad Höffner" ,
+                                                                     "Patryk Burek" ,
+                                                                     "Ralph Schäfermeier" ;
+                                                          dc:description "GFO-object-extended-situation is an ontology design pattern for modeling extended object situations."@en ;
+                                                          dc:modified "2024-12-11" ;
+                                                          dc:title "General Formal Ontology (extended object situation pattern)"@en ;
+                                                          terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                          bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                          vann:preferredNamespacePrefix "gfo-object-extended-situation" ;
+                                                          vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/object-extended" ;
+                                                          doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                          rdfs:label "GFO object-extended situation pattern"@en ;
+                                                          owl:versionInfo "2024-12-11" ;
+                                                          foaf:homepage "https://github.com/Onto-Med/GFO" .
 
 #################################################################
 #    Annotation properties
@@ -109,59 +109,19 @@ foaf:homepage rdf:type owl:AnnotationProperty .
 #    Object Properties
 #################################################################
 
-###  https://w3id.org/gfo/core/attributiveOf
-gfo-core:attributiveOf rdf:type owl:ObjectProperty ;
-                       owl:inverseOf gfo-core:hasAttributive ;
-                       rdfs:range gfo-core:Individual ;
-                       rdfs:label "attributive of"@en .
-
-
-###  https://w3id.org/gfo/core/hasAttributive
-gfo-core:hasAttributive rdf:type owl:ObjectProperty ;
-                        rdfs:domain gfo-core:Individual ;
-                        rdfs:label "has attributive"@en .
-
-
 ###  https://w3id.org/gfo/core/hasPart
 gfo-core:hasPart rdf:type owl:ObjectProperty ;
-                 owl:inverseOf gfo-core:partOf ;
-                 rdfs:domain gfo-core:Individual ;
-                 rdfs:range gfo-core:Individual ;
                  rdfs:label "has part"@en .
-
-
-###  https://w3id.org/gfo/core/hasParticipant
-gfo-core:hasParticipant rdf:type owl:ObjectProperty ;
-                        owl:inverseOf gfo-core:participatesIn ;
-                        rdfs:label "has participant"@en .
 
 
 ###  https://w3id.org/gfo/core/hasParticipantQuality
 gfo-core:hasParticipantQuality rdf:type owl:ObjectProperty ;
-                               rdfs:subPropertyOf :hasSituationPart ;
-                               owl:inverseOf gfo-core:participantQualityOf ;
                                rdfs:label "has participant quality"@en .
 
 
 ###  https://w3id.org/gfo/core/hasQuality
 gfo-core:hasQuality rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf gfo-core:hasAttributive ;
-                    owl:inverseOf gfo-core:qualityOf ;
-                    rdfs:domain gfo-core:Individual ;
                     rdfs:label "has quality"@en .
-
-
-###  https://w3id.org/gfo/core/partOf
-gfo-core:partOf rdf:type owl:ObjectProperty ;
-                rdfs:domain gfo-core:Individual ;
-                rdfs:range gfo-core:Individual ;
-                rdfs:label "part of"@en .
-
-
-###  https://w3id.org/gfo/core/participantQualityOf
-gfo-core:participantQualityOf rdf:type owl:ObjectProperty ;
-                              rdfs:subPropertyOf :situationPartOf ;
-                              rdfs:label "participant quality of"@en .
 
 
 ###  https://w3id.org/gfo/core/participatesIn
@@ -169,55 +129,19 @@ gfo-core:participatesIn rdf:type owl:ObjectProperty ;
                         rdfs:label "participates in"@en .
 
 
-###  https://w3id.org/gfo/core/playedBy
-gfo-core:playedBy rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf gfo-core:attributiveOf ;
-                  owl:inverseOf gfo-core:plays ;
-                  rdfs:label "played by"@en .
-
-
 ###  https://w3id.org/gfo/core/plays
 gfo-core:plays rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf gfo-core:hasAttributive ;
                rdfs:label "plays"@en .
-
-
-###  https://w3id.org/gfo/core/qualityOf
-gfo-core:qualityOf rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf gfo-core:attributiveOf ;
-                   rdfs:range gfo-core:Individual ;
-                   rdfs:label "quality of"@en .
 
 
 ###  https://w3id.org/gfo/core/relatedBy
 gfo-core:relatedBy rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf gfo-core:hasAttributive ;
-                   owl:inverseOf gfo-core:relates ;
                    rdfs:label "related by"@en .
-
-
-###  https://w3id.org/gfo/core/relates
-gfo-core:relates rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf gfo-core:attributiveOf ;
-                 rdfs:label "relates"@en .
 
 
 ###  https://w3id.org/gfo/core/roleIn
 gfo-core:roleIn rdf:type owl:ObjectProperty ;
-                rdfs:label "role in"@en .
-
-
-###  https://w3id.org/gfo/situation/hasSituationPart
-:hasSituationPart rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf gfo-core:hasPart ;
-                  owl:inverseOf :situationPartOf ;
-                  rdfs:label "has situation part"@en .
-
-
-###  https://w3id.org/gfo/situation/situationPartOf
-:situationPartOf rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf gfo-core:partOf ;
-                 rdfs:label "situation part of"@en .
+                rdfs:subPropertyOf owl:topObjectProperty .
 
 
 #################################################################
@@ -226,59 +150,55 @@ gfo-core:roleIn rdf:type owl:ObjectProperty ;
 
 ###  https://w3id.org/gfo/core/Attributive
 gfo-core:Attributive rdf:type owl:Class ;
-                     rdfs:subClassOf gfo-core:TimeExtendedIndividual ,
-                                     [ rdf:type owl:Restriction ;
-                                       owl:onProperty gfo-core:attributiveOf ;
-                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                       owl:onClass gfo-core:TimeExtendedIndividual
-                                     ] ;
                      rdfs:comment "Qualities (attributes, traits, characteristics, etc.) of concrete individuals, relations (relators) between them and roles that objects can play in different contexts are subsumed under the category Attributive."@en ;
                      rdfs:label "Attributive"@en ;
                      skos:definition "Attributives are individuals that depend on other individuals by some kind of dependency relation."@en .
 
 
-###  https://w3id.org/gfo/core/ConcreteIndividual
-gfo-core:ConcreteIndividual rdf:type owl:Class ;
-                            rdfs:subClassOf gfo-core:Individual ;
-                            rdfs:label "Concrete individual"@en ;
-                            skos:definition "Concrete individuals are entities that have an immediate relation to time or to space-time. They exist in time."@en .
-
-
-###  https://w3id.org/gfo/core/Individual
-gfo-core:Individual rdf:type owl:Class ;
-                    rdfs:label "Individual"@en ;
-                    skos:definition "Individuals are entities which cannot be further instantiated."@en .
-
-
 ###  https://w3id.org/gfo/core/Object
 gfo-core:Object rdf:type owl:Class ;
-                rdfs:subClassOf gfo-core:TimeExtendedIndividual ;
+                rdfs:subClassOf _:genid1 ,
+                                _:genid3 ;
                 rdfs:label "Object"@en ;
                 skos:altLabel "Continuant"@en ;
                 skos:definition "An object is understood as a mutable entity that persists over time, having a finite lifespan of non-zero duration. As such, it specializes gfo:Continuant."@en ;
                 skos:example "Physical, tangible entities such as apples, cells and organisms"@en .
 
+_:genid1 rdf:type owl:Restriction ;
+          owl:onProperty gfo-core:plays ;
+          owl:allValuesFrom gfo-core:Role .
+
+_:genid3 rdf:type owl:Restriction ;
+          owl:onProperty gfo-core:relatedBy ;
+          owl:allValuesFrom gfo-core:Relator .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource gfo-core:Object ;
+   owl:annotatedProperty rdfs:subClassOf ;
+   owl:annotatedTarget _:genid1 ;
+   rdfs:comment "As opposed to PresenticObject plays only PresenticRole" ,
+                "Should this axiom be part of gfo-core?"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource gfo-core:Object ;
+   owl:annotatedProperty rdfs:subClassOf ;
+   owl:annotatedTarget _:genid3 ;
+   rdfs:comment "As opposed to PresenticObject relatedBy only PresenticRelator" ,
+                "Should this axiom be part of gfo-core?"
+ ] .
+
 
 ###  https://w3id.org/gfo/core/Quality
 gfo-core:Quality rdf:type owl:Class ;
-                 rdfs:subClassOf gfo-core:Attributive ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty gfo-core:qualityOf ;
-                                   owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass gfo-core:TimeExtendedIndividual
-                                 ] ;
+                 rdfs:subClassOf gfo-core:Attributive ;
                  rdfs:label "Quality"@en ;
                  skos:definition "A quality links an entity—the necessary quality bearer—to a value, which can be quantitative (e.g., 10 kg, 40 $) or qualitative (e.g., ‘green’, ‘nice’)."@en .
 
 
 ###  https://w3id.org/gfo/core/Relator
 gfo-core:Relator rdf:type owl:Class ;
-                 rdfs:subClassOf gfo-core:Attributive ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty gfo-core:relates ;
-                                   owl:minQualifiedCardinality "2"^^xsd:nonNegativeInteger ;
-                                   owl:onClass gfo-core:Object
-                                 ] ;
+                 rdfs:subClassOf gfo-core:Attributive ;
                  rdfs:label "Relator"@en ;
                  skos:definition "Relators are attributives that connect other entities (role players) by relational roles (played by role players)."@en ;
                  skos:example "The marriage (relator) of John and Mary (in which Mary plays the wife role and John the husband role)"@en .
@@ -288,11 +208,6 @@ gfo-core:Relator rdf:type owl:Class ;
 gfo-core:Role rdf:type owl:Class ;
               rdfs:subClassOf gfo-core:Attributive ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty gfo-core:playedBy ;
-                                owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                owl:onClass gfo-core:Object
-                              ] ,
-                              [ rdf:type owl:Restriction ;
                                 owl:onProperty gfo-core:roleIn ;
                                 owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass gfo-core:Relator
@@ -301,30 +216,37 @@ gfo-core:Role rdf:type owl:Class ;
               skos:definition "A role characterizes an entity—its required player—through its context (e.g., relation/relator)."@en .
 
 
-###  https://w3id.org/gfo/core/TimeExtendedIndividual
-gfo-core:TimeExtendedIndividual rdf:type owl:Class ;
-                                rdfs:subClassOf gfo-core:ConcreteIndividual ;
-                                rdfs:label "Time-extended individual"@en .
-
-
 ###  https://w3id.org/gfo/situation/Situation
 :Situation rdf:type owl:Class ;
-           rdfs:subClassOf gfo-core:TimeExtendedIndividual ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty gfo-core:hasParticipant ;
-                             owl:someValuesFrom gfo-core:Object
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty gfo-core:hasParticipantQuality ;
-                             owl:someValuesFrom gfo-core:Quality
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty :hasSituationPart ;
-                             owl:someValuesFrom gfo-core:Attributive
-                           ] ;
+           rdfs:subClassOf _:genid6 ,
+                           _:genid8 ;
            rdfs:comment "In line with GFO, we assume that every situation consists of at least one object that participates_in the situation."@en ;
            rdfs:label "Situation"@en ;
            skos:definition "Situations as complex entities that are comprehended as wholes"@en .
+
+_:genid6 rdf:type owl:Restriction ;
+          owl:onProperty gfo-core:hasPart ;
+          owl:allValuesFrom :Situation .
+
+_:genid8 rdf:type owl:Restriction ;
+          owl:onProperty gfo-core:hasParticipantQuality ;
+          owl:allValuesFrom gfo-core:Quality .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :Situation ;
+   owl:annotatedProperty rdfs:subClassOf ;
+   owl:annotatedTarget _:genid6 ;
+   rdfs:comment "As opposed to PresenticSituation hasPart only PresenticSituation" ,
+                "Should this axiom be part of gfo-core?"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :Situation ;
+   owl:annotatedProperty rdfs:subClassOf ;
+   owl:annotatedTarget _:genid8 ;
+   rdfs:comment "As opposed to PresenticSituation hasPArticipantQuality only PresenticQuality" ,
+                "Should this axiom be part of gfo-core?"
+ ] .
 
 
 ###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/gfo-situation-presentic-object-reified-presentic-attributives.ttl
+++ b/modules/situation/gfo-situation-presentic-object-reified-presentic-attributives.ttl
@@ -1,0 +1,171 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-attributives> rdf:type owl:Ontology ;
+                                                                                          owl:versionIRI <https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-attributives/release/2024-12-19> ;
+                                                                                          dc:created "2024-12-11" ;
+                                                                                          dc:creator "Alexandr Uciteli" ,
+                                                                                                     "Christoph Beger" ,
+                                                                                                     "Frank Löbe" ,
+                                                                                                     "Franz Matthies" ,
+                                                                                                     "Heinrich Herre" ,
+                                                                                                     "Konrad Höffner" ,
+                                                                                                     "Patryk Burek" ,
+                                                                                                     "Ralph Schäfermeier" ;
+                                                                                          dc:description "GFO-presentic-object-reified-presentic-attributives-situation is an ontology design pattern for modeling presentic-object-reified-presentic-attributives situations."@en ;
+                                                                                          dc:modified "2024-12-11" ;
+                                                                                          dc:title "General Formal Ontology (presentic-object-reified-presentic-attributives situation pattern)"@en ;
+                                                                                          terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                                                          bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                                          vann:preferredNamespacePrefix "gfo-presentic-object-reified-presentic-attributives-situation" ;
+                                                                                          vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-attributives" ;
+                                                                                          doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                                                          rdfs:label "GFO presentic-object-reified-presentic-attributives situation pattern"@en ;
+                                                                                          owl:versionInfo "2024-12-11" ;
+                                                                                          foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  https://w3id.org/gfo/core/hasAttributive
+gfo-core:hasAttributive rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf owl:topObjectProperty ;
+                        rdfs:label "has attributive"@en .
+
+
+###  https://w3id.org/gfo/core/hasPart
+gfo-core:hasPart rdf:type owl:ObjectProperty ;
+                 rdfs:label "has part"@en .
+
+
+###  https://w3id.org/gfo/core/hasTime
+gfo-core:hasTime rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf owl:topObjectProperty ;
+                 rdfs:label "has time"@en .
+
+
+###  https://w3id.org/gfo/core/participatesIn
+gfo-core:participatesIn rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf owl:topObjectProperty ;
+                        rdfs:label "participates in"@en .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/gfo/core/Object
+gfo-core:Object rdf:type owl:Class ;
+                rdfs:label "Object"@en ;
+                skos:altLabel "Continuant"@en ;
+                skos:definition "An object is understood as a mutable entity that persists over time, having a finite lifespan of non-zero duration. As such, it specializes gfo:Continuant."@en ;
+                skos:example "Physical, tangible entities such as apples, cells and organisms"@en .
+
+
+###  https://w3id.org/gfo/core/PresenticAttributive
+gfo-core:PresenticAttributive rdf:type owl:Class ;
+                              rdfs:label "Presentic attributive"@en .
+
+
+###  https://w3id.org/gfo/core/TimeInterval
+gfo-core:TimeInterval rdf:type owl:Class ;
+                      rdfs:label "Time interval"@en ;
+                      skos:altLabel "Chronoid"@en ,
+                                    "Time period"@en .
+
+
+###  https://w3id.org/gfo/core/TimePoint
+gfo-core:TimePoint rdf:type owl:Class ;
+                   rdfs:label "Time point"@en ;
+                   skos:altLabel "Point in time"@en ,
+                                 "Time boundary"@en .
+
+
+###  https://w3id.org/gfo/situation/PresenticSituation
+:PresenticSituation rdf:type owl:Class ;
+                    rdfs:label "Presentic situation"@en .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/gfo-situation-presentic-object-reified-presentic-attributives.ttl
+++ b/modules/situation/gfo-situation-presentic-object-reified-presentic-attributives.ttl
@@ -111,7 +111,6 @@ foaf:homepage rdf:type owl:AnnotationProperty .
 
 ###  https://w3id.org/gfo/core/hasAttributive
 gfo-core:hasAttributive rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf owl:topObjectProperty ;
                         rdfs:label "has attributive"@en .
 
 
@@ -122,13 +121,11 @@ gfo-core:hasPart rdf:type owl:ObjectProperty ;
 
 ###  https://w3id.org/gfo/core/hasTime
 gfo-core:hasTime rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf owl:topObjectProperty ;
                  rdfs:label "has time"@en .
 
 
 ###  https://w3id.org/gfo/core/participatesIn
 gfo-core:participatesIn rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf owl:topObjectProperty ;
                         rdfs:label "participates in"@en .
 
 

--- a/modules/situation/gfo-situation-presentic-object-reified-presentic-objects.ttl
+++ b/modules/situation/gfo-situation-presentic-object-reified-presentic-objects.ttl
@@ -111,7 +111,6 @@ foaf:homepage rdf:type owl:AnnotationProperty .
 
 ###  https://w3id.org/gfo/core/hasAttributive
 gfo-core:hasAttributive rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf owl:topObjectProperty ;
                         rdfs:label "has attributive"@en .
 
 
@@ -122,19 +121,16 @@ gfo-core:hasPart rdf:type owl:ObjectProperty ;
 
 ###  https://w3id.org/gfo/core/hasTime
 gfo-core:hasTime rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf owl:topObjectProperty ;
                  rdfs:label "has time"@en .
 
 
 ###  https://w3id.org/gfo/core/participatesIn
 gfo-core:participatesIn rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf owl:topObjectProperty ;
                         rdfs:label "participates in"@en .
 
 
 ###  https://w3id.org/gfo/core/snapshotOf
 gfo-core:snapshotOf rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf owl:topObjectProperty ;
                     rdfs:label "snapshot of"@en .
 
 

--- a/modules/situation/gfo-situation-presentic-object-reified-presentic-objects.ttl
+++ b/modules/situation/gfo-situation-presentic-object-reified-presentic-objects.ttl
@@ -1,0 +1,183 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-objects> rdf:type owl:Ontology ;
+                                                                                     owl:versionIRI <https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-objects/release/2024-12-19> ;
+                                                                                     dc:created "2024-12-11" ;
+                                                                                     dc:creator "Alexandr Uciteli" ,
+                                                                                                "Christoph Beger" ,
+                                                                                                "Frank Löbe" ,
+                                                                                                "Franz Matthies" ,
+                                                                                                "Heinrich Herre" ,
+                                                                                                "Konrad Höffner" ,
+                                                                                                "Patryk Burek" ,
+                                                                                                "Ralph Schäfermeier" ;
+                                                                                     dc:description "GFO-presentic-object-reified-presentic-objects-situation is an ontology design pattern for modeling presentic-object-reified-presentic-objects situations."@en ;
+                                                                                     dc:modified "2024-12-11" ;
+                                                                                     dc:title "General Formal Ontology (presentic-object-reified-presentic-objects situation pattern)"@en ;
+                                                                                     terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                                                     bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                                     vann:preferredNamespacePrefix "gfo-presentic-object-reified-presentic-objects-situation" ;
+                                                                                     vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-objects" ;
+                                                                                     doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                                                     rdfs:label "GFO presentic-object-reified-presentic-objects situation pattern"@en ;
+                                                                                     owl:versionInfo "2024-12-11" ;
+                                                                                     foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  https://w3id.org/gfo/core/hasAttributive
+gfo-core:hasAttributive rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf owl:topObjectProperty ;
+                        rdfs:label "has attributive"@en .
+
+
+###  https://w3id.org/gfo/core/hasPart
+gfo-core:hasPart rdf:type owl:ObjectProperty ;
+                 rdfs:label "has part"@en .
+
+
+###  https://w3id.org/gfo/core/hasTime
+gfo-core:hasTime rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf owl:topObjectProperty ;
+                 rdfs:label "has time"@en .
+
+
+###  https://w3id.org/gfo/core/participatesIn
+gfo-core:participatesIn rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf owl:topObjectProperty ;
+                        rdfs:label "participates in"@en .
+
+
+###  https://w3id.org/gfo/core/snapshotOf
+gfo-core:snapshotOf rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf owl:topObjectProperty ;
+                    rdfs:label "snapshot of"@en .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/gfo/core/Object
+gfo-core:Object rdf:type owl:Class ;
+                rdfs:label "Object"@en ;
+                skos:altLabel "Continuant"@en ;
+                skos:definition "An object is understood as a mutable entity that persists over time, having a finite lifespan of non-zero duration. As such, it specializes gfo:Continuant."@en ;
+                skos:example "Physical, tangible entities such as apples, cells and organisms"@en .
+
+
+###  https://w3id.org/gfo/core/PresenticAttributive
+gfo-core:PresenticAttributive rdf:type owl:Class ;
+                              rdfs:label "Presentic attributive"@en .
+
+
+###  https://w3id.org/gfo/core/PresenticObject
+gfo-core:PresenticObject rdf:type owl:Class ;
+                         rdfs:label "Presentic object"@en ;
+                         skos:definition "Each object manifests itself at any given time point of its existence as a presentic object (the latter is then a snapshot_of the former). A presentic object is likewise a complete whole, but with a lifetime of a unique time point, at which it is fully present."@en .
+
+
+###  https://w3id.org/gfo/core/TimeInterval
+gfo-core:TimeInterval rdf:type owl:Class ;
+                      rdfs:label "Time interval"@en ;
+                      skos:altLabel "Chronoid"@en ,
+                                    "Time period"@en .
+
+
+###  https://w3id.org/gfo/core/TimePoint
+gfo-core:TimePoint rdf:type owl:Class ;
+                   rdfs:label "Time point"@en ;
+                   skos:altLabel "Point in time"@en ,
+                                 "Time boundary"@en .
+
+
+###  https://w3id.org/gfo/situation/PresenticSituation
+:PresenticSituation rdf:type owl:Class ;
+                    rdfs:label "Presentic situation"@en .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/gfo-situation-presentic-object.ttl
+++ b/modules/situation/gfo-situation-presentic-object.ttl
@@ -1,0 +1,173 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/presentic-object> rdf:type owl:Ontology ;
+                                                           owl:versionIRI <https://w3id.org/gfo/pattern/situation/presentic-object/release/2024-12-19> ;
+                                                           dc:created "2024-12-11" ;
+                                                           dc:creator "Alexandr Uciteli" ,
+                                                                      "Christoph Beger" ,
+                                                                      "Frank Löbe" ,
+                                                                      "Franz Matthies" ,
+                                                                      "Heinrich Herre" ,
+                                                                      "Konrad Höffner" ,
+                                                                      "Patryk Burek" ,
+                                                                      "Ralph Schäfermeier" ;
+                                                           dc:description "GFO-presentic-object-situation is an ontology design pattern for modeling presentic object situations."@en ;
+                                                           dc:modified "2024-12-11" ;
+                                                           dc:title "General Formal Ontology (presentic object situation pattern)"@en ;
+                                                           terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                           bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                           vann:preferredNamespacePrefix "gfo-presentic-object-situation" ;
+                                                           vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object" ;
+                                                           doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                           rdfs:label "GFO presentic-object situation pattern"@en ;
+                                                           owl:versionInfo "2024-12-11" ;
+                                                           foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  https://w3id.org/gfo/core/hasPart
+gfo-core:hasPart rdf:type owl:ObjectProperty ;
+                 rdfs:label "has part"@en .
+
+
+###  https://w3id.org/gfo/core/hasAttributive
+gfo-core:hasAttributive rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf owl:topObjectProperty ;
+                        rdfs:label "has attributive"@en .
+
+
+###  https://w3id.org/gfo/core/hasTime
+gfo-core:hasTime rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf owl:topObjectProperty ;
+                 rdfs:label "has time"@en .
+
+
+###  https://w3id.org/gfo/core/participatesIn
+gfo-core:participatesIn rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf owl:topObjectProperty ;
+                        rdfs:label "participates in"@en .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/gfo/core/Attributive
+gfo-core:Attributive rdf:type owl:Class ;
+                     rdfs:comment "Qualities (attributes, traits, characteristics, etc.) of concrete individuals, relations (relators) between them and roles that objects can play in different contexts are subsumed under the category Attributive."@en ;
+                     rdfs:label "Attributive"@en ;
+                     skos:definition "Attributives are individuals that depend on other individuals by some kind of dependency relation."@en .
+
+
+###  https://w3id.org/gfo/core/Object
+gfo-core:Object rdf:type owl:Class ;
+                rdfs:label "Object"@en ;
+                skos:altLabel "Continuant"@en ;
+                skos:definition "An object is understood as a mutable entity that persists over time, having a finite lifespan of non-zero duration. As such, it specializes gfo:Continuant."@en ;
+                skos:example "Physical, tangible entities such as apples, cells and organisms"@en .
+
+
+###  https://w3id.org/gfo/core/TimeInterval
+gfo-core:TimeInterval rdf:type owl:Class ;
+                      rdfs:label "Time interval"@en ;
+                      skos:altLabel "Chronoid"@en ,
+                                    "Time period"@en .
+
+
+###  https://w3id.org/gfo/core/TimePoint
+gfo-core:TimePoint rdf:type owl:Class ;
+                   rdfs:label "Time point"@en ;
+                   skos:altLabel "Point in time"@en ,
+                                 "Time boundary"@en .
+
+
+###  https://w3id.org/gfo/situation/PresenticSituation
+:PresenticSituation rdf:type owl:Class ;
+                    rdfs:label "Presentic situation"@en .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/gfo-situation-presentic-object.ttl
+++ b/modules/situation/gfo-situation-presentic-object.ttl
@@ -116,19 +116,16 @@ gfo-core:hasPart rdf:type owl:ObjectProperty ;
 
 ###  https://w3id.org/gfo/core/hasAttributive
 gfo-core:hasAttributive rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf owl:topObjectProperty ;
                         rdfs:label "has attributive"@en .
 
 
 ###  https://w3id.org/gfo/core/hasTime
 gfo-core:hasTime rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf owl:topObjectProperty ;
                  rdfs:label "has time"@en .
 
 
 ###  https://w3id.org/gfo/core/participatesIn
 gfo-core:participatesIn rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf owl:topObjectProperty ;
                         rdfs:label "participates in"@en .
 
 

--- a/modules/situation/gfo-situation-presentic-simple.ttl
+++ b/modules/situation/gfo-situation-presentic-simple.ttl
@@ -126,7 +126,6 @@ gfo-core:hasQuality rdf:type owl:ObjectProperty ;
 
 ###  https://w3id.org/gfo/core/hasTime
 gfo-core:hasTime rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf owl:topObjectProperty ;
                  rdfs:label "has time"@en .
 
 

--- a/modules/situation/gfo-situation-presentic-simple.ttl
+++ b/modules/situation/gfo-situation-presentic-simple.ttl
@@ -14,28 +14,28 @@
 @prefix gfo-core: <https://w3id.org/gfo/core/> .
 @base <https://w3id.org/gfo/situation/> .
 
-<https://w3id.org/gfo/pattern/situation/object> rdf:type owl:Ontology ;
-                                                 owl:versionIRI <https://w3id.org/gfo/pattern/situation/object/release/2024-12-19> ;
-                                                 dc:created "2024-12-11" ;
-                                                 dc:creator "Alexandr Uciteli" ,
-                                                            "Christoph Beger" ,
-                                                            "Frank Löbe" ,
-                                                            "Franz Matthies" ,
-                                                            "Heinrich Herre" ,
-                                                            "Konrad Höffner" ,
-                                                            "Patryk Burek" ,
-                                                            "Ralph Schäfermeier" ;
-                                                 dc:description "GFO-object-situation is an ontology design pattern for modeling object situations."@en ;
-                                                 dc:modified "2024-12-11" ;
-                                                 dc:title "General Formal Ontology (object situation pattern)"@en ;
-                                                 terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                 bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
-                                                 vann:preferredNamespacePrefix "gfo-object-situation" ;
-                                                 vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/object" ;
-                                                 doap:repository <https://github.com/Onto-Med/GFO> ;
-                                                 rdfs:label "GFO object situation pattern"@en ;
-                                                 owl:versionInfo "2024-12-11" ;
-                                                 foaf:homepage "https://github.com/Onto-Med/GFO" .
+<https://w3id.org/gfo/pattern/situation/presentic-simple> rdf:type owl:Ontology ;
+                                                           owl:versionIRI <https://w3id.org/gfo/pattern/situation/presentic-simple/release/2024-12-19> ;
+                                                           dc:created "2024-12-11" ;
+                                                           dc:creator "Alexandr Uciteli" ,
+                                                                      "Christoph Beger" ,
+                                                                      "Frank Löbe" ,
+                                                                      "Franz Matthies" ,
+                                                                      "Heinrich Herre" ,
+                                                                      "Konrad Höffner" ,
+                                                                      "Patryk Burek" ,
+                                                                      "Ralph Schäfermeier" ;
+                                                           dc:description "GFO-presentic-simple-situation is an ontology design pattern for modeling simple presentic situations."@en ;
+                                                           dc:modified "2024-12-11" ;
+                                                           dc:title "General Formal Ontology (simple presentic situation pattern)"@en ;
+                                                           terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                           bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                           vann:preferredNamespacePrefix "gfo-presentic-simple-situation" ;
+                                                           vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-simple" ;
+                                                           doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                           rdfs:label "GFO presentic-simple situation pattern"@en ;
+                                                           owl:versionInfo "2024-12-11" ;
+                                                           foaf:homepage "https://github.com/Onto-Med/GFO" .
 
 #################################################################
 #    Annotation properties
@@ -124,34 +124,15 @@ gfo-core:hasQuality rdf:type owl:ObjectProperty ;
                     rdfs:label "has quality"@en .
 
 
-###  https://w3id.org/gfo/core/partOf
-gfo-core:partOf rdf:type owl:ObjectProperty ;
-                rdfs:label "part of"@en .
-
-
-###  https://w3id.org/gfo/core/participatesIn
-gfo-core:participatesIn rdf:type owl:ObjectProperty ;
-                        rdfs:label "participates in"@en .
+###  https://w3id.org/gfo/core/hasTime
+gfo-core:hasTime rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf owl:topObjectProperty ;
+                 rdfs:label "has time"@en .
 
 
 #################################################################
 #    Classes
 #################################################################
-
-###  https://w3id.org/gfo/core/Individual
-gfo-core:Individual rdf:type owl:Class ;
-                    rdfs:label "Individual"@en ;
-                    skos:definition "Individuals are entities which cannot be further instantiated."@en .
-
-
-###  https://w3id.org/gfo/core/Object
-gfo-core:Object rdf:type owl:Class ;
-                rdfs:subClassOf gfo-core:Individual ;
-                rdfs:label "Object"@en ;
-                skos:altLabel "Continuant"@en ;
-                skos:definition "An object is understood as a mutable entity that persists over time, having a finite lifespan of non-zero duration. As such, it specializes gfo:Continuant."@en ;
-                skos:example "Physical, tangible entities such as apples, cells and organisms"@en .
-
 
 ###  https://w3id.org/gfo/core/Quality
 gfo-core:Quality rdf:type owl:Class ;
@@ -159,12 +140,16 @@ gfo-core:Quality rdf:type owl:Class ;
                  skos:definition "A quality links an entity—the necessary quality bearer—to a value, which can be quantitative (e.g., 10 kg, 40 $) or qualitative (e.g., ‘green’, ‘nice’)."@en .
 
 
-###  https://w3id.org/gfo/situation/Situation
-:Situation rdf:type owl:Class ;
-           rdfs:subClassOf gfo-core:Individual ;
-           rdfs:comment "In line with GFO, we assume that every situation consists of at least one object that participates_in the situation."@en ;
-           rdfs:label "Situation"@en ;
-           skos:definition "Situations as complex entities that are comprehended as wholes"@en .
+###  https://w3id.org/gfo/core/TimePoint
+gfo-core:TimePoint rdf:type owl:Class ;
+                   rdfs:label "Time point"@en ;
+                   skos:altLabel "Point in time"@en ,
+                                 "Time boundary"@en .
+
+
+###  https://w3id.org/gfo/situation/PresenticSituation
+:PresenticSituation rdf:type owl:Class ;
+                    rdfs:label "Presentic situation"@en .
 
 
 ###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/gfo-situation-simple.ttl
+++ b/modules/situation/gfo-situation-simple.ttl
@@ -14,28 +14,28 @@
 @prefix gfo-core: <https://w3id.org/gfo/core/> .
 @base <https://w3id.org/gfo/situation/> .
 
-<https://w3id.org/gfo/situation/simple> rdf:type owl:Ontology ;
-                                         owl:versionIRI <https://w3id.org/gfo/simple/release/2024-12-11> ;
-                                         dc:created "2024-12-11" ;
-                                         dc:creator "Alexandr Uciteli" ,
-                                                    "Christoph Beger" ,
-                                                    "Frank Löbe" ,
-                                                    "Franz Matthies" ,
-                                                    "Heinrich Herre" ,
-                                                    "Konrad Höffner" ,
-                                                    "Patryk Burek" ,
-                                                    "Ralph Schäfermeier" ;
-                                         dc:description "GFO-situation-simple is an ontology design pattern for modeling simple situations."@en ;
-                                         dc:modified "2024-12-11" ;
-                                         dc:title "General Formal Ontology (simple situation pattern)"@en ;
-                                         terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                         bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
-                                         vann:preferredNamespacePrefix "gfo-situation-simple" ;
-                                         vann:preferredNamespaceURI "https://w3id.org/gfo/situation/simple" ;
-                                         doap:repository <https://github.com/Onto-Med/GFO> ;
-                                         rdfs:label "GFO-situation-simple"@en ;
-                                         owl:versionInfo "2024-12-11" ;
-                                         foaf:homepage "https://github.com/Onto-Med/GFO" .
+<https://w3id.org/gfo/pattern/situation/simple> rdf:type owl:Ontology ;
+                                                 owl:versionIRI <https://w3id.org/gfo/pattern/situation/simple/release/2024-12-19> ;
+                                                 dc:created "2024-12-11" ;
+                                                 dc:creator "Alexandr Uciteli" ,
+                                                            "Christoph Beger" ,
+                                                            "Frank Löbe" ,
+                                                            "Franz Matthies" ,
+                                                            "Heinrich Herre" ,
+                                                            "Konrad Höffner" ,
+                                                            "Patryk Burek" ,
+                                                            "Ralph Schäfermeier" ;
+                                                 dc:description "GFO-simple-situation is an ontology design pattern for modeling simple situations."@en ;
+                                                 dc:modified "2024-12-11" ;
+                                                 dc:title "General Formal Ontology (simple situation pattern)"@en ;
+                                                 terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                 bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                 vann:preferredNamespacePrefix "gfo-simple-situation" ;
+                                                 vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/simple" ;
+                                                 doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                 rdfs:label "GFO simple situation pattern"@en ;
+                                                 owl:versionInfo "2024-12-11" ;
+                                                 foaf:homepage "https://github.com/Onto-Med/GFO" .
 
 #################################################################
 #    Annotation properties
@@ -109,98 +109,24 @@ foaf:homepage rdf:type owl:AnnotationProperty .
 #    Object Properties
 #################################################################
 
-###  https://w3id.org/gfo/core/attributiveOf
-gfo-core:attributiveOf rdf:type owl:ObjectProperty ;
-                       owl:inverseOf gfo-core:hasAttributive ;
-                       rdfs:range gfo-core:Individual ;
-                       rdfs:label "attributive of"@en .
-
-
-###  https://w3id.org/gfo/core/hasAttributive
-gfo-core:hasAttributive rdf:type owl:ObjectProperty ;
-                        rdfs:domain gfo-core:Individual ;
-                        rdfs:label "has attributive"@en .
-
-
 ###  https://w3id.org/gfo/core/hasPart
 gfo-core:hasPart rdf:type owl:ObjectProperty ;
-                 owl:inverseOf gfo-core:partOf ;
-                 rdfs:domain gfo-core:Individual ;
-                 rdfs:range gfo-core:Individual ;
                  rdfs:label "has part"@en .
 
 
 ###  https://w3id.org/gfo/core/hasParticipantQuality
 gfo-core:hasParticipantQuality rdf:type owl:ObjectProperty ;
-                               rdfs:subPropertyOf :hasSituationPart ;
-                               owl:inverseOf gfo-core:participantQualityOf ;
                                rdfs:label "has participant quality"@en .
 
 
 ###  https://w3id.org/gfo/core/hasQuality
 gfo-core:hasQuality rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf gfo-core:hasAttributive ;
-                    owl:inverseOf gfo-core:qualityOf ;
-                    rdfs:domain gfo-core:Individual ;
                     rdfs:label "has quality"@en .
-
-
-###  https://w3id.org/gfo/core/partOf
-gfo-core:partOf rdf:type owl:ObjectProperty ;
-                rdfs:domain gfo-core:Individual ;
-                rdfs:range gfo-core:Individual ;
-                rdfs:label "part of"@en .
-
-
-###  https://w3id.org/gfo/core/participantQualityOf
-gfo-core:participantQualityOf rdf:type owl:ObjectProperty ;
-                              rdfs:subPropertyOf :situationPartOf ;
-                              rdfs:label "participant quality of"@en .
-
-
-###  https://w3id.org/gfo/core/qualityOf
-gfo-core:qualityOf rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf gfo-core:attributiveOf ;
-                   rdfs:range gfo-core:Individual ;
-                   rdfs:label "quality of"@en .
-
-
-###  https://w3id.org/gfo/situation/hasSituationPart
-:hasSituationPart rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf gfo-core:hasPart ;
-                  owl:inverseOf :situationPartOf ;
-                  rdfs:label "has situation part"@en .
-
-
-###  https://w3id.org/gfo/situation/situationPartOf
-:situationPartOf rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf gfo-core:partOf ;
-                 rdfs:label "situation part of"@en .
 
 
 #################################################################
 #    Classes
 #################################################################
-
-###  https://w3id.org/gfo/core/Attributive
-gfo-core:Attributive rdf:type owl:Class ;
-                     rdfs:subClassOf gfo-core:TimeExtendedIndividual ,
-                                     [ rdf:type owl:Restriction ;
-                                       owl:onProperty gfo-core:attributiveOf ;
-                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                       owl:onClass gfo-core:TimeExtendedIndividual
-                                     ] ;
-                     rdfs:comment "Qualities (attributes, traits, characteristics, etc.) of concrete individuals, relations (relators) between them and roles that objects can play in different contexts are subsumed under the category Attributive."@en ;
-                     rdfs:label "Attributive"@en ;
-                     skos:definition "Attributives are individuals that depend on other individuals by some kind of dependency relation."@en .
-
-
-###  https://w3id.org/gfo/core/ConcreteIndividual
-gfo-core:ConcreteIndividual rdf:type owl:Class ;
-                            rdfs:subClassOf gfo-core:Individual ;
-                            rdfs:label "Concrete individual"@en ;
-                            skos:definition "Concrete individuals are entities that have an immediate relation to time or to space-time. They exist in time."@en .
-
 
 ###  https://w3id.org/gfo/core/Individual
 gfo-core:Individual rdf:type owl:Class ;
@@ -210,33 +136,13 @@ gfo-core:Individual rdf:type owl:Class ;
 
 ###  https://w3id.org/gfo/core/Quality
 gfo-core:Quality rdf:type owl:Class ;
-                 rdfs:subClassOf gfo-core:Attributive ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty gfo-core:qualityOf ;
-                                   owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass gfo-core:TimeExtendedIndividual
-                                 ] ;
                  rdfs:label "Quality"@en ;
                  skos:definition "A quality links an entity—the necessary quality bearer—to a value, which can be quantitative (e.g., 10 kg, 40 $) or qualitative (e.g., ‘green’, ‘nice’)."@en .
 
 
-###  https://w3id.org/gfo/core/TimeExtendedIndividual
-gfo-core:TimeExtendedIndividual rdf:type owl:Class ;
-                                rdfs:subClassOf gfo-core:ConcreteIndividual ;
-                                rdfs:label "Time-extended individual"@en .
-
-
 ###  https://w3id.org/gfo/situation/Situation
 :Situation rdf:type owl:Class ;
-           rdfs:subClassOf gfo-core:TimeExtendedIndividual ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty gfo-core:hasParticipantQuality ;
-                             owl:someValuesFrom gfo-core:Quality
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty :hasSituationPart ;
-                             owl:someValuesFrom gfo-core:Attributive
-                           ] ;
+           rdfs:subClassOf gfo-core:Individual ;
            rdfs:comment "In line with GFO, we assume that every situation consists of at least one object that participates_in the situation."@en ;
            rdfs:label "Situation"@en ;
            skos:definition "Situations as complex entities that are comprehended as wholes"@en .

--- a/modules/situation/gfo-situation-time-extended.ttl
+++ b/modules/situation/gfo-situation-time-extended.ttl
@@ -1,0 +1,198 @@
+@prefix : <https://w3id.org/gfo/situation/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@prefix gfo-core: <https://w3id.org/gfo/core/> .
+@base <https://w3id.org/gfo/situation/> .
+
+<https://w3id.org/gfo/pattern/situation/time-extended> rdf:type owl:Ontology ;
+                                                        owl:versionIRI <https://w3id.org/gfo/pattern/situation/time-extended/release/2024-12-19> ;
+                                                        dc:created "2024-12-11" ;
+                                                        dc:creator "Alexandr Uciteli" ,
+                                                                   "Christoph Beger" ,
+                                                                   "Frank Löbe" ,
+                                                                   "Franz Matthies" ,
+                                                                   "Heinrich Herre" ,
+                                                                   "Konrad Höffner" ,
+                                                                   "Patryk Burek" ,
+                                                                   "Ralph Schäfermeier" ;
+                                                        dc:description "GFO-time-extended-situation is an ontology design pattern for modeling time-extended situations."@en ;
+                                                        dc:modified "2024-12-11" ;
+                                                        dc:title "General Formal Ontology (time-extended situation pattern)"@en ;
+                                                        terms:license <http://creativecommons.org/licenses/by/4.0/> ;
+                                                        bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                        vann:preferredNamespacePrefix "gfo-time-extended-situation" ;
+                                                        vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/time-extended" ;
+                                                        doap:repository <https://github.com/Onto-Med/GFO> ;
+                                                        rdfs:label "GFO time-extended situation pattern"@en ;
+                                                        owl:versionInfo "2024-12-11" ;
+                                                        foaf:homepage "https://github.com/Onto-Med/GFO" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/created
+dc:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/modified
+dc:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+terms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/ontology/bibo/doi
+bibo:doi rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceURI
+vann:preferredNamespaceURI rdf:type owl:AnnotationProperty .
+
+
+###  http://usefulinc.com/ns/doap#repository
+doap:repository rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://xmlns.com/foaf/0.1/homepage
+foaf:homepage rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  https://w3id.org/gfo/core/followUp
+gfo-core:followUp rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf owl:topObjectProperty ;
+                  rdfs:label "follow up"@en .
+
+
+###  https://w3id.org/gfo/core/hasPart
+gfo-core:hasPart rdf:type owl:ObjectProperty ;
+                 rdfs:label "has part"@en .
+
+
+###  https://w3id.org/gfo/core/hasTime
+gfo-core:hasTime rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf owl:topObjectProperty ;
+                 rdfs:label "has time"@en .
+
+
+###  https://w3id.org/gfo/core/participatesIn
+gfo-core:participatesIn rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf owl:topObjectProperty ;
+                        rdfs:label "participates in"@en .
+
+
+###  https://w3id.org/gfo/core/snapshotOf
+gfo-core:snapshotOf rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf owl:topObjectProperty ;
+                    rdfs:label "snapshot of"@en .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/gfo/core/Attributive
+gfo-core:Attributive rdf:type owl:Class ;
+                     rdfs:comment "Qualities (attributes, traits, characteristics, etc.) of concrete individuals, relations (relators) between them and roles that objects can play in different contexts are subsumed under the category Attributive."@en ;
+                     rdfs:label "Attributive"@en ;
+                     skos:definition "Attributives are individuals that depend on other individuals by some kind of dependency relation."@en .
+
+
+###  https://w3id.org/gfo/core/Object
+gfo-core:Object rdf:type owl:Class ;
+                rdfs:label "Object"@en ;
+                skos:altLabel "Continuant"@en ;
+                skos:definition "An object is understood as a mutable entity that persists over time, having a finite lifespan of non-zero duration. As such, it specializes gfo:Continuant."@en ;
+                skos:example "Physical, tangible entities such as apples, cells and organisms"@en .
+
+
+###  https://w3id.org/gfo/core/PresenticAttributive
+gfo-core:PresenticAttributive rdf:type owl:Class ;
+                              rdfs:label "Presentic attributive"@en .
+
+
+###  https://w3id.org/gfo/core/PresenticObject
+gfo-core:PresenticObject rdf:type owl:Class ;
+                         rdfs:label "Presentic object"@en ;
+                         skos:definition "Each object manifests itself at any given time point of its existence as a presentic object (the latter is then a snapshot_of the former). A presentic object is likewise a complete whole, but with a lifetime of a unique time point, at which it is fully present."@en .
+
+
+###  https://w3id.org/gfo/core/TimeInterval
+gfo-core:TimeInterval rdf:type owl:Class ;
+                      rdfs:label "Time interval"@en ;
+                      skos:altLabel "Chronoid"@en ,
+                                    "Time period"@en .
+
+
+###  https://w3id.org/gfo/core/TimePoint
+gfo-core:TimePoint rdf:type owl:Class .
+
+
+###  https://w3id.org/gfo/situation/PresenticSituation
+:PresenticSituation rdf:type owl:Class ;
+                    rdfs:label "Presentic situation"@en .
+
+
+###  https://w3id.org/gfo/situation/Situation
+:Situation rdf:type owl:Class ;
+           rdfs:subClassOf [ rdf:type owl:Restriction ;
+                             owl:onProperty gfo-core:hasPart ;
+                             owl:allValuesFrom :Situation
+                           ] ;
+           rdfs:comment "In line with GFO, we assume that every situation consists of at least one object that participates_in the situation."@en ;
+           rdfs:label "Situation"@en ;
+           skos:definition "Situations as complex entities that are comprehended as wholes"@en .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/modules/situation/gfo-situation-time-extended.ttl
+++ b/modules/situation/gfo-situation-time-extended.ttl
@@ -111,7 +111,6 @@ foaf:homepage rdf:type owl:AnnotationProperty .
 
 ###  https://w3id.org/gfo/core/followUp
 gfo-core:followUp rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf owl:topObjectProperty ;
                   rdfs:label "follow up"@en .
 
 
@@ -122,19 +121,16 @@ gfo-core:hasPart rdf:type owl:ObjectProperty ;
 
 ###  https://w3id.org/gfo/core/hasTime
 gfo-core:hasTime rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf owl:topObjectProperty ;
                  rdfs:label "has time"@en .
 
 
 ###  https://w3id.org/gfo/core/participatesIn
 gfo-core:participatesIn rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf owl:topObjectProperty ;
                         rdfs:label "participates in"@en .
 
 
 ###  https://w3id.org/gfo/core/snapshotOf
 gfo-core:snapshotOf rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf owl:topObjectProperty ;
                     rdfs:label "snapshot of"@en .
 
 


### PR DESCRIPTION
This PR completes the implementation of the situation patterns from the JAO paper and adds an example to each one.

Some of the existing pattern implementations had to be simplified, i.e., class restrictions had to be removed because they would have left to inconsistencies when combining different patterns.