### PR TITLE
Fix all occurrences of the zenodo doi of gfo

### DIFF
--- a/gfo-light.owl
+++ b/gfo-light.owl
@@ -23,7 +23,7 @@
         <vann:preferredNamespacePrefix>gfo-light</vann:preferredNamespacePrefix>
         <foaf:homepage>https://github.com/Onto-Med/GFO</foaf:homepage>
         <doap:repository rdf:resource="https://github.com/Onto-Med/GFO"/>
-        <bibo:doi rdf:resource="https://zenodo.org/doi/10.5281/zenodo.5205419"/>
+        <bibo:doi>10.5281/zenodo.5205419</bibo:doi>
         <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
     </owl:Ontology>
     

--- a/gfo.owl
+++ b/gfo.owl
@@ -28,7 +28,7 @@
     <vann:preferredNamespacePrefix>gfo</vann:preferredNamespacePrefix>
     <foaf:homepage>https://github.com/Onto-Med/GFO</foaf:homepage>
     <doap:repository rdf:resource="https://github.com/Onto-Med/GFO" />
-    <bibo:doi rdf:resource="https://zenodo.org/doi/10.5281/zenodo.5205419" />
+    <bibo:doi>10.5281/zenodo.5205419</bibo:doi>
     <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
   </owl:Ontology>
 </rdf:RDF>

--- a/modules/gfo-base.owl
+++ b/modules/gfo-base.owl
@@ -26,7 +26,7 @@
     <vann:preferredNamespacePrefix>gfo-base</vann:preferredNamespacePrefix>
     <foaf:homepage>https://github.com/Onto-Med/GFO</foaf:homepage>
     <doap:repository rdf:resource="https://github.com/Onto-Med/GFO" />
-    <bibo:doi rdf:resource="https://zenodo.org/doi/10.5281/zenodo.5205419" />
+    <bibo:doi>10.5281/zenodo.5205419</bibo:doi>
     <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
   </owl:Ontology>
 

--- a/modules/situation/examples/gfo-situation-object-example.ttl
+++ b/modules/situation/examples/gfo-situation-object-example.ttl
@@ -32,7 +32,7 @@
                                                          dc:modified "2024-12-11" ;
                                                          dc:title "General Formal Ontology (object situation pattern example)"@en ;
                                                          terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                         bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                         bibo:doi "10.5281/zenodo.5205419" ;
                                                          vann:preferredNamespacePrefix "gfo-object-situation-example" ;
                                                          vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/object-example" ;
                                                          doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/examples/gfo-situation-object-extended-example.ttl
+++ b/modules/situation/examples/gfo-situation-object-extended-example.ttl
@@ -31,7 +31,7 @@
                                                                   dc:modified "2024-12-11" ;
                                                                   dc:title "General Formal Ontology (extended object situation pattern example)"@en ;
                                                                   terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                                  bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                  bibo:doi "10.5281/zenodo.5205419" ;
                                                                   vann:preferredNamespacePrefix "gfo-object-extended-situation-example" ;
                                                                   vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/object-extended-example" ;
                                                                   doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/examples/gfo-situation-presentic-object-example.ttl
+++ b/modules/situation/examples/gfo-situation-presentic-object-example.ttl
@@ -32,7 +32,7 @@
                                                                    dc:modified "2024-12-11" ;
                                                                    dc:title "General Formal Ontology (presentic object situation pattern example)"@en ;
                                                                    terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                                   bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                   bibo:doi "10.5281/zenodo.5205419" ;
                                                                    vann:preferredNamespacePrefix "gfo-presentic-object-situation-example" ;
                                                                    vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object-example" ;
                                                                    doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/examples/gfo-situation-presentic-object-reified-presentic-attributives-example.ttl
+++ b/modules/situation/examples/gfo-situation-presentic-object-reified-presentic-attributives-example.ttl
@@ -32,7 +32,7 @@
                                                                                                   dc:modified "2024-12-11" ;
                                                                                                   dc:title "General Formal Ontology (presentic-object-reified-presentic-attributives situation pattern example)"@en ;
                                                                                                   terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                                                                  bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                                                  bibo:doi "10.5281/zenodo.5205419" ;
                                                                                                   vann:preferredNamespacePrefix "gfo-presentic-object-reified-presentic-attributives-situation-example" ;
                                                                                                   vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-attributives-example" ;
                                                                                                   doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/examples/gfo-situation-presentic-object-reified-presentic-objects-example.ttl
+++ b/modules/situation/examples/gfo-situation-presentic-object-reified-presentic-objects-example.ttl
@@ -32,7 +32,7 @@
                                                                                              dc:modified "2024-12-11" ;
                                                                                              dc:title "General Formal Ontology (presentic-object-reified-presentic-objects situation pattern example)"@en ;
                                                                                              terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                                                             bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                                             bibo:doi "10.5281/zenodo.5205419" ;
                                                                                              vann:preferredNamespacePrefix "gfo-presentic-object-reified-presentic-objects-situation-example" ;
                                                                                              vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-objects-example" ;
                                                                                              doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/examples/gfo-situation-presentic-simple-example.ttl
+++ b/modules/situation/examples/gfo-situation-presentic-simple-example.ttl
@@ -32,7 +32,7 @@
                                                                    dc:modified "2024-12-11" ;
                                                                    dc:title "General Formal Ontology (simple presentic situation pattern example)"@en ;
                                                                    terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                                   bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                   bibo:doi "10.5281/zenodo.5205419" ;
                                                                    vann:preferredNamespacePrefix "gfo-presentic-simple-situation-example" ;
                                                                    vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-simple-example" ;
                                                                    doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/examples/gfo-situation-simple-example.ttl
+++ b/modules/situation/examples/gfo-situation-simple-example.ttl
@@ -32,7 +32,7 @@
                                                          dc:modified "2024-12-11" ;
                                                          dc:title "General Formal Ontology (simple situation pattern example)"@en ;
                                                          terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                         bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                         bibo:doi "10.5281/zenodo.5205419" ;
                                                          vann:preferredNamespacePrefix "gfo-simple-situation-example" ;
                                                          vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/simple-example" ;
                                                          doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/examples/gfo-situation-time-extended-example.ttl
+++ b/modules/situation/examples/gfo-situation-time-extended-example.ttl
@@ -32,7 +32,7 @@
                                                                 dc:modified "2024-12-11" ;
                                                                 dc:title "General Formal Ontology (time-extended situation pattern example)"@en ;
                                                                 terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                                bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                bibo:doi "10.5281/zenodo.5205419" ;
                                                                 vann:preferredNamespacePrefix "gfo-time-extended-situation-example" ;
                                                                 vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/time-extended-example" ;
                                                                 doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/gfo-situation-object-extended.ttl
+++ b/modules/situation/gfo-situation-object-extended.ttl
@@ -29,7 +29,7 @@
                                                           dc:modified "2024-12-11" ;
                                                           dc:title "General Formal Ontology (extended object situation pattern)"@en ;
                                                           terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                          bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                          bibo:doi "10.5281/zenodo.5205419" ;
                                                           vann:preferredNamespacePrefix "gfo-object-extended-situation" ;
                                                           vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/object-extended" ;
                                                           doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/gfo-situation-object.ttl
+++ b/modules/situation/gfo-situation-object.ttl
@@ -29,7 +29,7 @@
                                                  dc:modified "2024-12-11" ;
                                                  dc:title "General Formal Ontology (object situation pattern)"@en ;
                                                  terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                 bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                 bibo:doi "10.5281/zenodo.5205419" ;
                                                  vann:preferredNamespacePrefix "gfo-object-situation" ;
                                                  vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/object" ;
                                                  doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/gfo-situation-presentic-object-reified-presentic-attributives.ttl
+++ b/modules/situation/gfo-situation-presentic-object-reified-presentic-attributives.ttl
@@ -29,7 +29,7 @@
                                                                                           dc:modified "2024-12-11" ;
                                                                                           dc:title "General Formal Ontology (presentic-object-reified-presentic-attributives situation pattern)"@en ;
                                                                                           terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                                                          bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                                          bibo:doi "10.5281/zenodo.5205419" ;
                                                                                           vann:preferredNamespacePrefix "gfo-presentic-object-reified-presentic-attributives-situation" ;
                                                                                           vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-attributives" ;
                                                                                           doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/gfo-situation-presentic-object-reified-presentic-objects.ttl
+++ b/modules/situation/gfo-situation-presentic-object-reified-presentic-objects.ttl
@@ -29,7 +29,7 @@
                                                                                      dc:modified "2024-12-11" ;
                                                                                      dc:title "General Formal Ontology (presentic-object-reified-presentic-objects situation pattern)"@en ;
                                                                                      terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                                                     bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                                                     bibo:doi "10.5281/zenodo.5205419" ;
                                                                                      vann:preferredNamespacePrefix "gfo-presentic-object-reified-presentic-objects-situation" ;
                                                                                      vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object-reified-presentic-objects" ;
                                                                                      doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/gfo-situation-presentic-object.ttl
+++ b/modules/situation/gfo-situation-presentic-object.ttl
@@ -29,7 +29,7 @@
                                                            dc:modified "2024-12-11" ;
                                                            dc:title "General Formal Ontology (presentic object situation pattern)"@en ;
                                                            terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                           bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                           bibo:doi "10.5281/zenodo.5205419" ;
                                                            vann:preferredNamespacePrefix "gfo-presentic-object-situation" ;
                                                            vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-object" ;
                                                            doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/gfo-situation-presentic-simple.ttl
+++ b/modules/situation/gfo-situation-presentic-simple.ttl
@@ -29,7 +29,7 @@
                                                            dc:modified "2024-12-11" ;
                                                            dc:title "General Formal Ontology (simple presentic situation pattern)"@en ;
                                                            terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                           bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                           bibo:doi "10.5281/zenodo.5205419" ;
                                                            vann:preferredNamespacePrefix "gfo-presentic-simple-situation" ;
                                                            vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/presentic-simple" ;
                                                            doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/gfo-situation-simple.ttl
+++ b/modules/situation/gfo-situation-simple.ttl
@@ -29,7 +29,7 @@
                                                  dc:modified "2024-12-11" ;
                                                  dc:title "General Formal Ontology (simple situation pattern)"@en ;
                                                  terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                 bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                 bibo:doi "10.5281/zenodo.5205419" ;
                                                  vann:preferredNamespacePrefix "gfo-simple-situation" ;
                                                  vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/simple" ;
                                                  doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/gfo-situation-time-extended.ttl
+++ b/modules/situation/gfo-situation-time-extended.ttl
@@ -29,7 +29,7 @@
                                                         dc:modified "2024-12-11" ;
                                                         dc:title "General Formal Ontology (time-extended situation pattern)"@en ;
                                                         terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                                        bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                                        bibo:doi "10.5281/zenodo.5205419" ;
                                                         vann:preferredNamespacePrefix "gfo-time-extended-situation" ;
                                                         vann:preferredNamespaceURI "https://w3id.org/gfo/pattern/situation/time-extended" ;
                                                         doap:repository <https://github.com/Onto-Med/GFO> ;

--- a/modules/situation/gfo-situation.ttl
+++ b/modules/situation/gfo-situation.ttl
@@ -29,7 +29,7 @@
                                   dc:modified "2024-12-07" ;
                                   dc:title "General Formal Ontology (situation module)"@en ;
                                   terms:license <http://creativecommons.org/licenses/by/4.0/> ;
-                                  bibo:doi <https://zenodo.org/doi/10.5281/zenodo.5205419> ;
+                                  bibo:doi "10.5281/zenodo.5205419" ;
                                   vann:preferredNamespacePrefix "gfo-situation" ;
                                   vann:preferredNamespaceURI "https://w3id.org/gfo/situation/" ;
                                   doap:repository <https://github.com/Onto-Med/GFO> ;


### PR DESCRIPTION
The Zenodo DOI of GFO is given as URL, which is not supported by Widoco. This PR replaces all occurrences of `https://zenodo.org/doi/10.5281/zenodo.5205419` with `10.5281/zenodo.5205419`.